### PR TITLE
feat: 优化品赞IP代理功能，添加网站分类和代理适用性检查

### DIFF
--- a/backend/services/task_service.py
+++ b/backend/services/task_service.py
@@ -6,7 +6,7 @@ Date created:               2025/02/16
 Description:                任务管理服务，提供问卷任务的创建、查询、执行和管理功能
 ----------------------------------------------------------------
 
-Changed history:            
+Changed history:
                             2025/02/22: 添加任务状态实时监控功能
                             2025/02/25: 增强任务并发处理能力
                             2025/04/17: 增强索引文件读写的鲁棒性
@@ -21,49 +21,51 @@ import logging
 import requests
 import threading
 import shutil
-from enum import Enum
-from config import Config
-from services.survey_service import SurveyService
-from core.wjx import WJXSubmitter
+import random
 from datetime import datetime
+from backend.config import Config
+from backend.services.survey_service import SurveyService
+from backend.core.wjx import WJXSubmitter
+from backend.core.llm_generator import LLMGenerator
+from backend.utils.proxy import normalize_proxy_url, get_proxy_from_api, test_proxy, get_and_test_proxy, is_china_website, should_use_pinzan_proxy
 
 logger = logging.getLogger(__name__)
 
 class TaskService:
     """
     任务管理服务类
-    
+
     负责问卷任务的创建、执行、监控和管理
     提供任务状态跟踪、数据存储和并发执行功能
     """
     def __init__(self):
         """
         初始化任务服务
-        
+
         设置任务存储目录和相关服务
         """
         self.survey_service = SurveyService()
-        
+
         # 任务目录 - 使用 Config 类属性
-        self.tasks_dir = Config.TASKS_DIR 
+        self.tasks_dir = Config.TASKS_DIR
         os.makedirs(self.tasks_dir, exist_ok=True)
-        
+
         # 任务索引文件 - 使用 Config 类属性
         self.index_file = Config.TASK_INDEX_FILE
-        
+
         # 加载任务索引
         self.index = self._load_index()
-        
+
         # 运行中的任务
         self.running_tasks = {}
-        
+
         # 恢复运行中的任务
         # self._restore_running_tasks()
-    
+
     def _load_index(self):
         """
         加载任务索引 (增强鲁棒性)
-        
+
         从索引文件中读取任务列表，失败时尝试备份文件
         """
         index_file = self.index_file
@@ -114,11 +116,11 @@ class TaskService:
             return []
         else:
             return loaded_index
-    
+
     def _save_index(self):
         """
         保存任务索引 (增强鲁棒性 - 原子写入)
-        
+
         将任务列表写入索引文件，使用临时文件和备份机制
         """
         index_file = self.index_file
@@ -151,11 +153,11 @@ class TaskService:
                     os.remove(temp_file)
                 except Exception as clean_e:
                     logger.error(f"清理临时任务索引文件失败: {clean_e}")
-    
+
     def _run_task(self, task_id, task_data):
         """
         执行后台任务
-        
+
         在单独线程中执行任务的主要逻辑
         """
         try:
@@ -164,18 +166,18 @@ class TaskService:
             if not survey:
                 self._update_task_status(task_id, 'failed', message="找不到问卷数据")
                 return
-            
+
             # 初始化计数器
             total = task_data.get('count', 1)
             success_count = 0
             fail_count = 0
-            
+
             # 更新任务状态
             self._update_task_status(task_id, 'running')
-            
+
             # 创建提交器
             submitter = WJXSubmitter(survey_url=survey['url'], survey_config=survey)
-            
+
             # 计算问卷复杂度
             survey_complexity = 5  # 默认中等复杂度
             if 'questions' in survey:
@@ -183,113 +185,147 @@ class TaskService:
                 num_questions = len(survey['questions'])
                 complex_types = sum(1 for q in survey['questions'] if q.get('type') in [4, 6, 11])  # 多选、矩阵、排序题
                 simple_types = sum(1 for q in survey['questions'] if q.get('type') in [1, 3, 5, 8])  # 填空、单选、量表、评分
-                
+
                 # 计算复杂度得分 (0-10)
                 survey_complexity = min(10, max(1, num_questions / 5 + complex_types * 0.5))
                 logger.info(f"问卷复杂度计算: {survey_complexity:.1f}/10 (问题数: {num_questions}, 复杂问题: {complex_types}, 简单问题: {simple_types})")
-            
+
             # 执行任务
             for i in range(total):
                 try:
                     # 生成随机答案
                     answer_data = self._generate_answer_data(survey)
-                    
+
                     # 提交问卷
                     result = submitter.submit(answer_data)
-                    
+
                     if result.get('success', False):
                         success_count += 1
                         logger.info(f"任务提交成功: {task_id}, 进度: {i+1}/{total}")
                     else:
                         fail_count += 1
                         logger.warning(f"任务提交失败: {task_id}, 进度: {i+1}/{total}, 错误: {result.get('message', '未知错误')}")
-                    
+
                     # 更新进度
                     progress = int((i + 1) / total * 100)
                     self._update_task_progress(task_id, progress, success_count, fail_count)
-                    
+
                     # 添加模拟人类行为的随机延迟
                     delay = self._generate_human_like_delay(i + 1, total, survey_complexity)
                     time.sleep(delay)
-                    
+
                 except Exception as e:
                     fail_count += 1
                     logger.error(f"任务执行异常: {e}")
-                    self._update_task_progress(task_id, 
-                                              int((i + 1) / total * 100), 
-                                              success_count, 
+                    self._update_task_progress(task_id,
+                                              int((i + 1) / total * 100),
+                                              success_count,
                                               fail_count)
-            
+
             # 任务完成
             final_status = 'completed' if success_count > 0 else 'failed'
             self._update_task_status(task_id, final_status)
             logger.info(f"任务执行完成: {task_id}, 成功: {success_count}, 失败: {fail_count}")
-        
+
         except Exception as e:
             logger.error(f"任务执行失败: {e}", exc_info=True)
             self._update_task_status(task_id, 'failed', message=f"执行错误: {str(e)}")
-    
+
     def _update_task_status(self, task_id, status, message=None):
         """
         更新任务状态
-        
+
         修改任务状态并保存到文件
         """
         task_file = os.path.join(self.tasks_dir, f"{task_id}.json")
         try:
             with open(task_file, 'r', encoding='utf-8') as f:
                 task_data = json.load(f)
-            
+
             task_data['status'] = status
             if message:
                 task_data['message'] = message
             task_data['updated_at'] = time.strftime("%Y-%m-%d %H:%M:%S")
-            
+
             with open(task_file, 'w', encoding='utf-8') as f:
                 json.dump(task_data, f, ensure_ascii=False, indent=2)
-            
+
             # 更新索引
             for task in self.index:
                 if task['id'] == task_id:
                     task['status'] = status
                     break
             self._save_index()
-            
+
             return True
         except Exception as e:
             logger.error(f"更新任务状态失败 {task_id}: {e}")
             return False
-    
+
     def _update_task_progress(self, task_id, progress, success_count, fail_count):
         """
         更新任务进度
-        
+
         修改任务进度并保存到文件
         """
         task_file = os.path.join(self.tasks_dir, f"{task_id}.json")
         try:
             with open(task_file, 'r', encoding='utf-8') as f:
                 task_data = json.load(f)
-            
+
             # 计算进度，确保在0-100之间
             progress = min(max(0, progress), 100)
-            
+
             # 更新任务数据
             task_data['progress'] = progress
             task_data['success_count'] = success_count
             task_data['fail_count'] = fail_count
             task_data['completed_count'] = success_count + fail_count
             task_data['total_count'] = task_data.get('count', 0)
-            task_data['updated_at'] = time.strftime("%Y-%m-%d %H:%M:%S")
-            
+            current_time = time.strftime("%Y-%m-%d %H:%M:%S")
+            task_data['updated_at'] = current_time
+
+            # 更新提交时间分布数据
+            if 'time_distribution' not in task_data:
+                task_data['time_distribution'] = []
+
+            # 使用更精确的时间点，包含分钟与秒钟
+            current_time = time.strftime("%H:%M:%S")
+
+            # 记录任务开始时间（如果还没有）
+            if 'start_time' not in task_data and success_count + fail_count > 0:
+                task_data['start_time'] = current_time
+
+            # 记录任务结束时间（如果完成了）
+            if task_data['completed_count'] >= task_data['total_count']:
+                task_data['end_time'] = current_time
+
+            # 检查是否已存在该时间点
+            found = False
+            for item in task_data['time_distribution']:
+                if item['time'] == current_time:
+                    item['count'] += 1
+                    found = True
+                    break
+
+            # 如果不存在，添加新的时间点
+            if not found:
+                task_data['time_distribution'].append({
+                    'time': current_time,
+                    'count': 1
+                })
+
+            # 按时间排序
+            task_data['time_distribution'].sort(key=lambda x: x['time'])
+
             # 如果所有提交都完成了，更新状态为完成
             if task_data['completed_count'] >= task_data['total_count']:
                 task_data['status'] = 'completed'
                 task_data['progress'] = 100
-            
+
             with open(task_file, 'w', encoding='utf-8') as f:
                 json.dump(task_data, f, ensure_ascii=False, indent=2)
-            
+
             # 更新索引
             for task in self.index:
                 if task['id'] == task_id:
@@ -298,27 +334,27 @@ class TaskService:
                         task['status'] = 'completed'
                     break
             self._save_index()
-            
+
             return True
         except Exception as e:
             logger.error(f"更新任务进度失败 {task_id}: {e}")
             return False
-    
+
     def create_task(self, task_data):
         """
         创建新任务
-        
+
         创建新的问卷提交任务
         """
         # 生成任务ID
         task_id = str(uuid.uuid4())
-        
+
         # 验证必需字段
         required_fields = ['survey_id']
         for field in required_fields:
             if field not in task_data:
                 raise ValueError(f"缺少必需字段: {field}")
-        
+
         # 设置默认值
         defaults = {
             'count': 1,
@@ -327,15 +363,15 @@ class TaskService:
             'use_llm': False,
             'llm_type': 'aliyun'
         }
-        
+
         for field, value in defaults.items():
             if field not in task_data:
                 task_data[field] = value
-        
+
         # 获取问卷信息
         logger.info(f"正在获取问卷: {task_data['survey_id']}")
         survey = self.survey_service.get_survey_by_id(task_data['survey_id'])
-        
+
         if not survey:
             # # 尝试重新解析问卷 # 注释掉或删除这部分
             # try:
@@ -349,7 +385,7 @@ class TaskService:
             #     else:
             #         # 构建默认URL
             #         url = f"https://www.wjx.cn/vm/{task_data['survey_id']}.aspx"
-            #     
+            #
             #     logger.info(f"尝试重新解析问卷: {url}")
             #     survey = self.survey_service.parse_survey(url)
             #     if not survey:
@@ -358,12 +394,36 @@ class TaskService:
             #     logger.error(f"重新解析问卷失败: {e}")
             #     raise ValueError(f"问卷不存在 {task_data['survey_id']}")
             raise ValueError(f"问卷不存在或加载失败: {task_data['survey_id']}，请确保在创建任务前已成功解析问卷。")
-        
+
+        # 如果启用了代理，获取代理信息
+        if task_data.get('use_proxy', False):
+            proxy_url = task_data.get('proxy_url') or os.environ.get('PINZAN_API_URL')
+            if proxy_url:
+                logger.info(f"任务创建时获取代理: {proxy_url}")
+                # 检查是否是品赞代理
+                is_pinzan = 'ipzan.com' in proxy_url
+                if is_pinzan:
+                    logger.warning("注意: 品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站")
+
+                # 使用改进的代理工具函数获取并测试代理，带重试机制
+                proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+                if proxy:
+                    logger.info(f"任务创建时成功获取代理: {proxy}")
+                    # 将代理信息存储在任务数据中
+                    task_data['proxy'] = proxy
+                    # 标记是否为品赞代理
+                    task_data['is_pinzan_proxy'] = is_pinzan
+                else:
+                    logger.warning(f"任务创建时获取代理失败，将使用直接连接方式提交")
+
         # 创建任务数据
         now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        current_time = datetime.now().strftime('%H:%M:%S')
+
         task = {
             'id': task_id,
             'survey_id': task_data['survey_id'],
+            'survey_title': survey.get('title', '未知问卷'),  # 添加问卷标题
             'count': task_data['count'],
             'created_at': now,
             'updated_at': now,
@@ -377,25 +437,39 @@ class TaskService:
             'proxy_url': task_data['proxy_url'],
             'use_llm': task_data['use_llm'],
             'llm_type': task_data['llm_type'],
-            'message': '任务创建成功，等待执行'
+            'message': '任务创建成功，等待执行',
+            # 初始化时间分布数据
+            'time_distribution': [
+                {
+                    'time': current_time,
+                    'count': 0
+                }
+            ],
+            # 记录创建时间作为初始时间点
+            'create_time': current_time
         }
-        
+
+        # 如果有代理信息，添加到任务数据中
+        if 'proxy' in task_data:
+            task['proxy'] = task_data['proxy']
+
         # 保存任务
         try:
             file_path = os.path.join(self.tasks_dir, f"{task_id}.json")
             with open(file_path, 'w', encoding='utf-8') as f:
                 json.dump(task, f, ensure_ascii=False, indent=2)
-            
+
             # 更新索引
             self.index.append({
                 'id': task_id,
                 'survey_id': task_data['survey_id'],
+                'survey_title': survey.get('title', '未知问卷'),  # 添加问卷标题
                 'created_at': now,
                 'status': 'pending',
                 'file_path': file_path
             })
             self._save_index()
-            
+
             # 启动后台任务
             thread = threading.Thread(
                 target=self._submit_task,
@@ -403,25 +477,25 @@ class TaskService:
             )
             thread.daemon = True
             thread.start()
-            
+
             logger.info(f"任务创建成功: {task_id}")
             return task_id
         except Exception as e:
             logger.error(f"创建任务异常: {e}", exc_info=True)
             raise Exception(f"创建任务失败: {str(e)}")
-    
+
     def get_all_tasks(self):
         """
         获取所有任务
-        
+
         返回任务索引列表
         """
         return self.index
-    
+
     def get_task_by_id(self, task_id):
         """
         获取指定任务详情
-        
+
         根据任务ID查找任务数据
         """
         for entry in self.index:
@@ -433,22 +507,22 @@ class TaskService:
                     logger.error(f"读取任务数据失败 {task_id}: {e}")
                     return None
         return None
-    
+
     def update_task_status(self, task_id, status):
         """
         更新任务状态
-        
+
         根据任务ID更新任务状态
         """
         task = self.get_task_by_id(task_id)
         if not task:
             return False
-        
+
         current_status = task['status']
-        
+
         if status == current_status:
             return True  # 状态没变，视为成功
-        
+
         if status == 'running':
             # 启动任务
             if current_status in ['created', 'paused']:
@@ -465,25 +539,25 @@ class TaskService:
                         self.running_tasks[task_id] = task_thread
                     return True
             return False
-            
+
         elif status == 'paused':
             # 暂停任务
             if current_status == 'running':
                 return self._update_task_status(task_id, 'paused')
             return False
-            
+
         elif status == 'stopped':
             # 停止任务
             if current_status in ['running', 'paused']:
                 return self._update_task_status(task_id, 'stopped')
             return False
-            
+
         return False
-    
+
     def delete_task(self, task_id):
         """
         删除任务
-        
+
         根据任务ID删除任务数据和索引
         """
         for i, entry in enumerate(self.index):
@@ -491,55 +565,55 @@ class TaskService:
                 try:
                     # 确保任务已停止
                     self.update_task_status(task_id, 'stopped')
-                    
+
                     # 删除任务文件
                     if os.path.exists(entry["file_path"]):
                         os.remove(entry["file_path"])
-                    
+
                     # 更新索引
                     self.index.pop(i)
                     self._save_index()
-                    
+
                     # 从运行任务字典中移除
                     if task_id in self.running_tasks:
                         del self.running_tasks[task_id]
-                    
+
                     return True
                 except Exception as e:
                     logger.error(f"删除任务失败 {task_id}: {e}")
                     return False
-        return False 
+        return False
 
     def _submit_task(self, task_id, task_data):
         """
         执行提交任务
-        
+
         负责任务的提交和状态更新
         """
         try:
             logger.info(f"开始执行任务: {task_id}")
-            
+
             # 查找问卷信息
             survey = self.survey_service.get_survey_by_id(task_data['survey_id'])
             if not survey:
                 self._update_task_status(task_id, 'failed', error="问卷不存在")
                 return
-            
+
             # 创建提交器实例
             submitter = WJXSubmitter(survey_url=survey['url'], survey_config=survey)
-            
+
             # 任务执行参数
             total = task_data.get('count', 1)
             success_count = 0
             fail_count = 0
-            
+
             # 更新任务状态为运行中
             self._update_task_status(task_id, 'running')
-            
+
             # 检查是否使用LLM生成答案
             use_llm = task_data.get('use_llm', False)
             llm_answers = None
-            
+
             # 计算问卷复杂度
             survey_complexity = 5  # 默认中等复杂度
             if 'questions' in survey:
@@ -547,171 +621,329 @@ class TaskService:
                 num_questions = len(survey['questions'])
                 complex_types = sum(1 for q in survey['questions'] if q.get('type') in [4, 6, 11])  # 多选、矩阵、排序题
                 simple_types = sum(1 for q in survey['questions'] if q.get('type') in [1, 3, 5, 8])  # 填空、单选、量表、评分
-                
+
                 # 计算复杂度得分 (0-10)
                 survey_complexity = min(10, max(1, num_questions / 5 + complex_types * 0.5))
                 logger.info(f"问卷复杂度计算: {survey_complexity:.1f}/10 (问题数: {num_questions}, 复杂问题: {complex_types}, 简单问题: {simple_types})")
-            
+
             # 如果使用LLM，生成答案数据
             if use_llm:
                 try:
                     from core.llm_generator import LLMGenerator
-                    
+
                     # 使用任务数据中的模型类型
                     llm_type = task_data.get('llm_type', 'aliyun')
                     logger.info(f"使用LLM生成器类型: {llm_type}")
-                    
+
                     # 根据不同模型类型获取对应环境变量中的API密钥
                     api_key = None
-                    if llm_type == 'aliyun':
-                        api_key = "sk-5662a97464e1404d8c6a06c68520abf6"
-                        logger.info("使用阿里云百炼API密钥")
-                        logger.debug(f"API密钥: {api_key}")
-                    
+                    env_key = f"{llm_type.upper()}_API_KEY"
+                    api_key = os.environ.get(env_key)
+
+                    if api_key:
+                        logger.info(f"使用{llm_type}模型的API密钥")
+                    else:
+                        # 如果没有找到环境变量中的API密钥，使用默认值
+                        if llm_type == 'aliyun':
+                            api_key = "sk-5662a97464e1404d8c6a06c68520abf6"
+                            logger.info("使用阿里云百炼默认API密钥")
+
+                    logger.debug(f"API密钥: {api_key}")
+
                     # 初始化LLM生成器
-                    llm_gen = LLMGenerator(model_type=llm_type, api_key=api_key)
-                    
+                    # 如果有代理，传递代理参数
+                    kwargs = {}
+                    # 初始化代理变量
+                    proxy = None
+
+                    # 如果任务设置中启用了代理
+                    if task_data.get('use_proxy', False):
+                        # 处理代理设置
+                        proxy_url = task_data.get('proxy_url') or os.environ.get('PINZAN_API_URL')
+                        if proxy_url:
+                            logger.info(f"使用代理URL: {proxy_url}")
+
+                            # 检查是否是品赞代理
+                            is_pinzan = 'ipzan.com' in proxy_url
+                            if is_pinzan:
+                                logger.warning("注意: 品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站")
+
+                                # 检查是否为国内LLM提供商
+                                is_china_llm = llm_type in ['aliyun', 'baidu', 'zhipu']
+                                if not is_china_llm:
+                                    logger.warning(f"品赞代理不适合访问国外LLM提供商({llm_type})，将使用直接连接")
+                                    # 如果不是国内LLM，不使用品赞代理
+                                    proxy_url = None
+
+                            # 使用改进的代理工具函数获取并测试代理，带重试机制
+                            # 使用更短的超时时间，加快失败检测
+                            proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+                            if proxy:
+                                logger.info(f"成功获取并测试代理: {proxy}")
+                                # 将代理信息存储在任务数据中，便于后续使用
+                                task_data['proxy'] = proxy
+                                # 标记是否为品赞代理
+                                task_data['is_pinzan_proxy'] = is_pinzan
+                            else:
+                                logger.warning(f"尝试了多个代理均测试失败，将使用直接连接初始化LLM: {llm_type}")
+
+                                # 尝试使用环境变量中的代理
+                                if os.environ.get('HTTP_PROXY'):
+                                    logger.info(f"尝试使用环境变量中的代理: {os.environ.get('HTTP_PROXY')}")
+                                    proxy = {'http': os.environ.get('HTTP_PROXY'), 'https': os.environ.get('HTTPS_PROXY') or os.environ.get('HTTP_PROXY')}
+                                    # 测试代理连接，使用短超时
+                                    if test_proxy(proxy, timeout=2):
+                                        logger.info(f"环境变量中的代理测试成功: {proxy}")
+                                    else:
+                                        logger.warning(f"环境变量中的代理测试失败: {proxy}")
+                                        proxy = None
+
+
+                            # 如果代理测试失败，记录错误
+                            if not proxy:
+                                logger.warning(f"代理测试失败，将使用直接连接")
+
+                    # 如果有代理，传递代理参数
+                    if proxy:
+                        # 对于阿里云，需要设置环境变量
+                        if llm_type == 'aliyun':
+                            # 设置环境变量代理
+                            if isinstance(proxy, dict):
+                                http_proxy = proxy.get('http')
+                                https_proxy = proxy.get('https')
+                                if http_proxy:
+                                    os.environ['HTTP_PROXY'] = http_proxy
+                                if https_proxy:
+                                    os.environ['HTTPS_PROXY'] = https_proxy
+                                logger.info(f"阿里云使用环境变量代理: HTTP_PROXY={http_proxy}, HTTPS_PROXY={https_proxy}")
+                        else:
+                            # 其他提供商支持代理参数
+                            # 删除所有代理相关的参数，然后添加proxy参数
+                            for key in list(kwargs.keys()):
+                                if 'proxy' in key.lower():
+                                    kwargs.pop(key, None)
+                            kwargs['proxy'] = proxy
+                            logger.info(f"使用代理初始化LLM: {llm_type}, 代理: {proxy}")
+                    else:
+                        logger.warning(f"未设置代理或代理测试失败，将使用直接连接初始化LLM: {llm_type}")
+
+                    # 初始化LLM生成器
+                    try:
+                        # 输出参数信息
+                        logger.info(f"开始初始化LLM生成器: model_type={llm_type}, api_key={api_key[:5]}...")
+                        logger.info(f"LLM生成器初始化参数 kwargs 包含的键: {list(kwargs.keys())}")
+
+                        # 初始化LLM生成器
+                        llm_gen = LLMGenerator(model_type=llm_type, api_key=api_key, **kwargs)
+                        logger.info(f"成功初始化LLM生成器: {llm_type}")
+                    except Exception as e:
+                        logger.error(f"LLM生成器初始化失败: {e}")
+                        logger.error(f"异常类型: {type(e).__name__}")
+                        logger.error(f"异常详情: {str(e)}")
+                        raise
+
                     # 调用生成答案
                     llm_answers = llm_gen.generate_answers(survey)
                     logger.info(f"已使用{llm_type}模型生成答案数据")
                     logger.debug(f"LLM生成的答案字典: {llm_answers}")
-                    
+
                     # 将答案字典转换为问卷星提交格式
                     formatted_answers = []
                     for idx, value in llm_answers.items():
                         formatted_answers.append(f"{idx}${value}")
                     answer_data = "}".join(formatted_answers)
                     logger.info(f"转换后的提交格式: {answer_data}")
-                    
+
                 except Exception as e:
                     logger.error(f"LLM生成答案失败: {e}", exc_info=True)
                     # 回退到随机生成
                     use_llm = False
                     answer_data = self._generate_answer_data(survey)
-            
+
             # 执行任务
             task_file = os.path.join(self.tasks_dir, f"{task_id}.json")
-            
+
             for i in range(total):
                 # 检查任务状态
                 with open(task_file, 'r', encoding='utf-8') as f:
                     current_task = json.load(f)
-                
+
                 if current_task['status'] != 'running':
                     logger.info(f"任务已暂停或停止: {task_id}")
                     break
-                
+
                 # 生成提交数据
                 try:
                     # 根据设置选择答案生成方式
                     if use_llm:
-                        # 直接使用已经格式化好的答案数据
-                        logger.info(f"使用LLM生成的答案: {answer_data}")
+                        # 检查任务数据中是否已经有答案
+                        if 'answers' in current_task and current_task['answers'] and i > 0:
+                            # 如果不是第一次提交，并且任务数据中有答案，则直接使用已有答案
+                            stored_answer_data = current_task['answers']
+                            logger.info(f"使用任务数据中的答案，避免重复调用LLM")
+                            answer_data = stored_answer_data
+                        else:
+                            # 直接使用已经格式化好的答案数据
+                            logger.info(f"使用LLM生成的答案: {answer_data}")
+                            # 将答案存储在任务数据中，便于后续使用
+                            current_task['answers'] = answer_data
+                            # 保存任务数据
+                            file_path = os.path.join(self.tasks_dir, f"{task_id}.json")
+                            with open(file_path, 'w', encoding='utf-8') as f:
+                                json.dump(current_task, f, ensure_ascii=False, indent=2)
                     else:
                         # 使用随机生成的答案
                         answer_data = self._generate_answer_data(survey)
-                    
+
                     # 使用代理
-                    proxy = None
-                    if task_data.get('use_proxy', False) and task_data.get('proxy_url'):
-                        proxy_url = task_data['proxy_url'].strip()
-                        if proxy_url:
-                            try:
-                                # 测试代理连接
-                                test_response = requests.get(
-                                    'https://www.baidu.cn',
-                                    proxies={'http': proxy_url, 'https': proxy_url},
-                                    timeout=5
-                                )
-                                # 如果能连接成功，设置代理
-                                if test_response.status_code == 200:
-                                    proxy = {'http': proxy_url, 'https': proxy_url}
-                                    logger.info(f"成功连接代理: {proxy_url}")
-                                else:
-                                    logger.warning(f"代理连接测试失败: {proxy_url}, 状态码: {test_response.status_code}")
-                            except Exception as e:
-                                logger.warning(f"代理连接测试异常: {proxy_url}, 错误: {e}")
-                                # 继续不使用代理
-                    
-                    # 如果代理测试失败，使用直接连接
+                    # 使用任务数据中存储的代理，避免重复获取
+                    proxy = current_task.get('proxy')
+
+                    # 如果任务数据中没有代理，但启用了代理功能，则尝试获取代理
                     if task_data.get('use_proxy', False) and not proxy:
-                        logger.warning(f"代理连接失败，将使用直接连接方式提交")
-                    
+                        logger.warning(f"任务数据中没有代理信息，尝试获取代理")
+                        proxy_url = task_data.get('proxy_url') or os.environ.get('PINZAN_API_URL')
+                        if proxy_url:
+                            logger.info(f"任务执行时获取代理: {proxy_url}")
+                            # 使用改进的代理工具函数获取并测试代理，带重试机制
+                            # 使用更短的超时时间，加快失败检测
+                            proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+                            if proxy:
+                                logger.info(f"任务执行时成功获取代理: {proxy}")
+                                # 更新任务数据中的代理信息
+                                current_task['proxy'] = proxy
+                                # 保存任务数据
+                                file_path = os.path.join(self.tasks_dir, f"{task_id}.json")
+                                with open(file_path, 'w', encoding='utf-8') as f:
+                                    json.dump(current_task, f, ensure_ascii=False, indent=2)
+                            else:
+                                logger.warning(f"任务执行时获取代理失败，将使用直接连接方式提交")
+                    elif proxy:
+                        logger.info(f"使用任务数据中的代理: {proxy}")
+
+                        # 检查是否是品赞代理
+                        is_pinzan = current_task.get('is_pinzan_proxy', False)
+                        if is_pinzan:
+                            logger.warning("注意: 品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站")
+
+                            # 检查问卷星是否为国内网站
+                            wjx_url = 'https://www.wjx.cn'
+                            if should_use_pinzan_proxy(wjx_url):
+                                logger.info(f"问卷星({wjx_url})是国内网站，可以使用品赞代理")
+                            else:
+                                logger.warning(f"问卷星({wjx_url})不是国内网站，但仍然尝试使用品赞代理")
+
+                        # 测试代理是否仍然可用，使用短超时
+                        if not test_proxy(proxy, timeout=2):
+                            logger.warning(f"任务数据中的代理测试失败，尝试重新获取代理")
+                            # 尝试重新获取代理
+                            proxy_url = task_data.get('proxy_url') or os.environ.get('PINZAN_API_URL')
+                            if proxy_url:
+                                logger.info(f"重新获取代理: {proxy_url}")
+
+                                # 检查是否是品赞代理
+                                is_pinzan = 'ipzan.com' in proxy_url
+                                if is_pinzan:
+                                    logger.warning("注意: 品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站")
+
+                                proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+                                if proxy:
+                                    logger.info(f"重新获取代理成功: {proxy}")
+                                    # 更新任务数据中的代理信息
+                                    current_task['proxy'] = proxy
+                                    # 标记是否为品赞代理
+                                    current_task['is_pinzan_proxy'] = is_pinzan
+                                    # 保存任务数据
+                                    file_path = os.path.join(self.tasks_dir, f"{task_id}.json")
+                                    with open(file_path, 'w', encoding='utf-8') as f:
+                                        json.dump(current_task, f, ensure_ascii=False, indent=2)
+                                else:
+                                    logger.warning(f"重新获取代理失败，将使用直接连接方式提交")
+                                    proxy = None
+                            else:
+                                logger.warning(f"没有代理URL，将使用直接连接方式提交")
+                                proxy = None
+
+                    # 如果使用LLM生成答案，但没有指定LLM类型，则使用默认的阿里云
+                    if task_data.get('use_llm', False) and not llm_type:
+                        llm_type = 'aliyun'
+                        logger.info(f"未指定LLM类型，使用默认的阿里云")
+
                     # 提交问卷
                     result = submitter.submit(answer_data, proxy)
-                    
+
                     if result.get('success', False):
                         success_count += 1
                         logger.info(f"任务 {task_id}: 第 {i+1}/{total} 次提交成功")
                     else:
                         fail_count += 1
                         logger.warning(f"任务 {task_id}: 第 {i+1}/{total} 次提交失败: {result.get('message', '未知错误')}")
-                    
+
                     # 更新进度
                     progress = int((i + 1) / total * 100)
                     self._update_task_progress(task_id, progress, success_count, fail_count)
-                    
+
                     # 添加模拟人类行为的随机延迟
                     delay = self._generate_human_like_delay(i + 1, total, survey_complexity)
                     time.sleep(delay)
-                    
+
                 except Exception as e:
                     fail_count += 1
                     logger.error(f"任务 {task_id}: 单次提交异常: {e}")
-                    self._update_task_progress(task_id, 
-                                               int((i + 1) / total * 100), 
-                                               success_count, 
+                    self._update_task_progress(task_id,
+                                               int((i + 1) / total * 100),
+                                               success_count,
                                                fail_count)
                     # 出错后短暂等待
                     time.sleep(3)
-            
+
             # 任务完成
             final_status = 'completed' if success_count > 0 else 'failed'
             final_msg = f"完成: 成功{success_count}次, 失败{fail_count}次"
             self._update_task_status(task_id, final_status, message=final_msg)
             logger.info(f"任务执行完成: {task_id}, {final_msg}")
-            
+
         except Exception as e:
             logger.error(f"提交任务失败: {e}", exc_info=True)
-            self._update_task_status(task_id, 'failed', error=str(e)) 
+            self._update_task_status(task_id, 'failed', message=str(e))
 
     def _generate_answer_data(self, survey):
         """
         根据问卷数据生成答案
-        
+
         自动生成答案数据
         """
         import random
         submit_data_parts = []
-        
+
         if not survey:
             logger.error("问卷数据为空")
             return ""
-        
+
         if 'questions' not in survey:
             logger.error("问卷数据格式错误: 缺少questions字段")
             return ""
-        
+
         if not survey['questions'] or len(survey['questions']) == 0:
             logger.error("问卷没有题目数据")
             return ""
-        
+
         questions = survey['questions']
         logger.info(f"开始生成答案，问卷题目数量: {len(questions)}")
-        
+
         for question in questions:
             try:
                 q_index = question.get('index', 0)
                 q_type = question.get('type', 0)
                 q_title = question.get('title', 'Unknown title')
-                
+
                 logger.debug(f"处理题目 {q_index}: {q_title} (类型: {q_type})")
-                
+
                 # 忽略隐藏题目
                 if question.get('is_hidden', False):
                     logger.debug(f"跳过隐藏题目: {q_index}")
                     continue
-                    
+
                 # 单选题 (3)
                 if q_type == 3:
                     if 'options' in question and len(question['options']) > 0:
@@ -719,7 +951,7 @@ class TaskService:
                         option_index = random.randint(0, len(question['options']) - 1)
                         submit_data_parts.append(f"{q_index}${option_index + 1}")
                         logger.debug(f"单选题 {q_index} 选择了选项 {option_index + 1}: {question['options'][option_index]}")
-                
+
                 # 多选题 (4)
                 elif q_type == 4:
                     if 'options' in question and len(question['options']) > 0:
@@ -730,7 +962,7 @@ class TaskService:
                         options_str = '|'.join([str(opt + 1) for opt in selected_options])
                         submit_data_parts.append(f"{q_index}${options_str}")
                         logger.debug(f"多选题 {q_index} 选择了选项: {options_str}")
-                
+
                 # 填空题 (1)
                 elif q_type == 1:
                     # 生成一个简单的填空回答
@@ -738,25 +970,53 @@ class TaskService:
                     text = random.choice(answers)
                     submit_data_parts.append(f"{q_index}${text}")
                     logger.debug(f"填空题 {q_index} 填写了: {text}")
-                
-                # 矩阵单选题 (6)
+
+                # 简答题 (2)
+                elif q_type == 2:
+                    # 简答题格式同填空题，但内容可以更长
+                    answers = [
+                        "我认为这个产品非常好用，推荐给大家。",
+                        "整体体验不错，但还有提升空间。",
+                        "使用过程中遇到了一些问题，希望能够改进。",
+                        "我对这个产品的意见是功能齐全，但界面可以更美观。",
+                        "建议增加更多的自定义选项，提高用户体验。"
+                    ]
+                    text = random.choice(answers)
+                    submit_data_parts.append(f"{q_index}${text}")
+                    logger.debug(f"简答题 {q_index} 填写了: {text}")
+
+                # 矩阵单选/多选/量表题 (6)
                 elif q_type == 6:
                     if 'options' in question and isinstance(question['options'], list):
                         if question['options'] and isinstance(question['options'][0], list):
-                            # 对每行随机选择一个选项
+                            # 检查是否为矩阵多选题
+                            is_matrix_checkbox = question.get('is_matrix_checkbox', False)
+
+                            # 对每行生成答案
                             row_answers = []
                             for i in range(len(question['options'])):
-                                # 对每行随机选择一个选项
                                 cols = len(question['options'][i])
                                 if cols > 0:
-                                    col_index = random.randint(0, cols - 1)
-                                    row_answers.append(str(col_index + 1))
-                            
+                                    if is_matrix_checkbox:
+                                        # 矩阵多选题，每行随机选择1-3个选项
+                                        num_to_select = min(random.randint(1, 3), cols)
+                                        selected_cols = random.sample(range(cols), num_to_select)
+                                        col_answers = []
+                                        for col in selected_cols:
+                                            col_answers.append(str(col + 1))
+                                        # 矩阵多选题的格式是“行号!(选项号1|选项号2|选项号3)”
+                                        row_answers.append(f"{i+1}!({','.join(col_answers)})")
+                                    else:
+                                        # 矩阵单选题，每行随机选择一个选项
+                                        col_index = random.randint(0, cols - 1)
+                                        # 矩阵单选题的格式是“行号!选项号”
+                                        row_answers.append(f"{i+1}!{col_index+1}")
+
                             if row_answers:
                                 answer = ','.join(row_answers)
                                 submit_data_parts.append(f"{q_index}${answer}")
                                 logger.debug(f"矩阵题 {q_index} 回答: {answer}")
-                
+
                 # 评分题 (8)
                 elif q_type == 8:
                     # 评分题通常是1-5或1-10分
@@ -764,11 +1024,11 @@ class TaskService:
                     if 'options' in question and len(question['options']) > 1:
                         if isinstance(question['options'][1], dict) and 'max' in question['options'][1]:
                             max_score = int(question['options'][1]['max'])
-                    
+
                     score = random.randint(1, max_score)
                     submit_data_parts.append(f"{q_index}${score}")
                     logger.debug(f"评分题 {q_index} 评分: {score}")
-                
+
                 # 排序题 (11)
                 elif q_type == 11:
                     if 'options' in question and len(question['options']) > 0:
@@ -776,71 +1036,122 @@ class TaskService:
                         num_options = len(question['options'])
                         order = list(range(1, num_options + 1))
                         random.shuffle(order)
-                        order_str = '|'.join(map(str, order))
+                        # 注意：排序题应该使用逗号（,）作为分隔符，而不是竖线（|）
+                        order_str = ','.join(map(str, order))
                         submit_data_parts.append(f"{q_index}${order_str}")
                         logger.debug(f"排序题 {q_index} 排序: {order_str}")
-                
-                # 量表题 (5)
+
+                # 下拉题 (7)
+                elif q_type == 7:
+                    if 'options' in question and len(question['options']) > 0:
+                        # 随机选择一个选项
+                        option_index = random.randint(0, len(question['options']) - 1)
+                        submit_data_parts.append(f"{q_index}${option_index + 1}")
+                        logger.debug(f"下拉题 {q_index} 选择了选项 {option_index + 1}: {question['options'][option_index]}")
+
+                # 量表题/评价题 (5)
                 elif q_type == 5:
                     # 量表题，随机选择一个值
                     scale_max = 5
+                    if 'max' in question:
+                        scale_max = int(question.get('max', 5))
                     value = random.randint(1, scale_max)
                     submit_data_parts.append(f"{q_index}${value}")
-                    logger.debug(f"量表题 {q_index} 选择: {value}")
-                
+
+                    # 如果是评价题，可能需要添加标签和评价内容
+                    is_evaluation = question.get('is_evaluation', False)
+                    if is_evaluation and 'evaluation_tags' in question and question['evaluation_tags']:
+                        # 评价题的标签和评价内容会自动添加到表单中，不需要额外处理
+                        logger.debug(f"评价题 {q_index} 选择: {value}, 有标签: {len(question['evaluation_tags'])}")
+                    else:
+                        logger.debug(f"量表题 {q_index} 选择: {value}")
+
+                # 矩阵填空/矩阵评分题 (9)
+                elif q_type == 9:
+                    # 检查是否有行标题
+                    if 'row_titles' in question and question['row_titles']:
+                        row_titles = question['row_titles']
+                        num_rows = len(row_titles)
+
+                        # 检查是否为个人信息填写
+                        is_personal_info = question.get('is_personal_info', False)
+
+                        # 生成每行的填空内容
+                        row_answers = []
+                        for i in range(num_rows):
+                            if is_personal_info:
+                                # 个人信息填写
+                                personal_info = ["张三", "18", "男", "北京", "13800138000", "test@example.com"]
+                                if i < len(personal_info):
+                                    row_answers.append(personal_info[i])
+                                else:
+                                    row_answers.append(f"信息{i+1}")
+                            else:
+                                # 普通矩阵填空
+                                row_answers.append(f"回答{i+1}")
+
+                        # 使用^(接口符)分隔不同行的填空内容
+                        answer = "^".join(row_answers)
+                        submit_data_parts.append(f"{q_index}${answer}")
+                        logger.debug(f"矩阵填空/评分题 {q_index} 回答: {answer}")
+                    else:
+                        # 如果没有行标题，使用默认回答
+                        submit_data_parts.append(f"{q_index}$默认回答")
+                        logger.debug(f"矩阵填空/评分题 {q_index} 使用默认回答")
+
                 # 如果是其他题型，记录日志
                 else:
                     logger.warning(f"未处理的题型 {q_type} 题目ID: {q_index}, 题目: {q_title}")
-                
+
             except Exception as e:
                 logger.error(f"生成问题 {q_index} 的答案时出错: {e}", exc_info=True)
                 # 跳过这个问题，继续处理下一个
-        
+
         # 将所有部分连接成一个字符串，使用 "}" 分隔
         submit_data = "}".join(submit_data_parts)
         logger.info(f"生成的提交数据包含 {len(submit_data_parts)} 个题目答案")
-        
+
         return submit_data
 
     def _generate_human_like_delay(self, current_task_num, total_tasks, survey_complexity=None):
         """
         生成模拟人类行为的随机延迟时间
-        
+
         根据当前任务进度、问卷复杂度等因素自适应调整延迟时间
-        
+
         Args:
             current_task_num: 当前是第几个任务
             total_tasks: 总任务数
             survey_complexity: 问卷复杂度（可选，由问题数量和类型决定）
-            
+
         Returns:
             float: 延迟时间（秒）
         """
         import random
         import math
-        
+
         # 基础延迟范围
         base_min_delay = 5
         base_max_delay = 15
-        
+
         # 1. 任务进度因素：开始和结束时更慢，中间更快
         progress_ratio = current_task_num / total_tasks
-        
+
         # 使用正态分布模拟：开始较慢，中间加速，结束前变慢
         # 这样的曲线更接近真实人类行为模式
         progress_factor = 1 - 0.5 * math.exp(-(pow(progress_ratio - 0.5, 2) / 0.05))
-        
+
         # 2. 引入自然变化：使用韦伯尔分布为延迟添加随机性
         # 这种分布比简单的均匀分布更接近人类随机性
-        randomness = random.weibullvariate(1, 2) 
+        randomness = random.weibullvariate(1, 2)
         while randomness > 3:  # 限制极端值
             randomness = random.weibullvariate(1, 2)
-        
+
         # 3. 时间段调整：如果能获取到当前时间，可以根据时间段调整
         import datetime
         current_hour = datetime.datetime.now().hour
         time_factor = 1.0
-        
+
         # 人们在不同时间段填写问卷的速度不同
         if 0 <= current_hour < 7:  # 深夜/凌晨：更慢
             time_factor = 1.3
@@ -854,48 +1165,48 @@ class TaskService:
             time_factor = 1.0
         else:  # 深夜：较慢
             time_factor = 1.1
-            
+
         # 4. 复杂度调整：根据问卷复杂度调整时间
         complexity_factor = 1.0
         if survey_complexity:
             # 简单问卷填写更快，复杂问卷填写更慢
             complexity_factor = 0.8 + (survey_complexity / 10) * 0.4  # 复杂度0-10的映射
-        
+
         # 5. 批量提交因素：连续提交多个问卷时，后面的提交速度会加快
         batch_factor = 1.0
         if total_tasks > 5:
             # 批量任务中，速度会逐渐加快，但到最后会略微放慢
             batch_curve = 1 - 0.3 * (progress_ratio * (1 - progress_ratio * 0.3))
             batch_factor = max(0.7, batch_curve)
-        
+
         # 6. 随机中断：模拟人类可能的暂停
         if random.random() < 0.05:  # 5%的概率出现较长暂停
             return random.uniform(20, 40)  # 随机暂停20-40秒
-            
+
         # 计算最终延迟时间
         final_min_delay = base_min_delay * progress_factor * time_factor * complexity_factor * batch_factor
         final_max_delay = base_max_delay * progress_factor * time_factor * complexity_factor * batch_factor
-        
+
         # 确保延迟时间在合理范围内
         final_min_delay = max(2, min(final_min_delay, 25))
         final_max_delay = max(final_min_delay + 2, min(final_max_delay, 40))
-        
+
         # 应用随机因子并返回最终延迟
         delay = final_min_delay + (final_max_delay - final_min_delay) * randomness / 3
-        
+
         # 记录延迟时间供调试
         logger.debug(f"生成的人类模拟延迟: {delay:.2f}秒 (进度: {progress_ratio:.2f}, 时间因子: {time_factor}, 复杂度: {complexity_factor})")
-        
+
         return delay
-        
+
     def get_tasks_paginated(self, page=1, page_size=10, sort_field='created_at', sort_order='desc'):
         """
         获取分页任务列表
-        
+
         根据页码和每页记录数返回任务列表
         """
         tasks = []
-        
+
         # 遍历索引获取详细任务信息
         for entry in self.index:
             try:
@@ -904,10 +1215,10 @@ class TaskService:
                     tasks.append(task)
             except Exception as e:
                 logger.error(f"读取任务数据失败 {entry['id']}: {e}")
-        
+
         # 排序
         reverse = sort_order.lower() == 'desc'
-        
+
         # 处理不同类型的字段排序
         if sort_field in ['progress', 'count', 'success_count', 'fail_count']:
             # 数值型字段
@@ -918,11 +1229,11 @@ class TaskService:
         else:
             # 字符串型字段
             tasks.sort(key=lambda x: str(x.get(sort_field, '')), reverse=reverse)
-        
+
         # 计算分页
         total = len(tasks)
         start_idx = (page - 1) * page_size
         end_idx = start_idx + page_size
-        
+
         # 返回当前页的数据
         return tasks[start_idx:end_idx], total

--- a/backend/utils/ip_tracker.py
+++ b/backend/utils/ip_tracker.py
@@ -15,6 +15,9 @@ import json
 import os
 import logging
 from datetime import datetime
+import requests
+
+# 导入后端配置模块
 from backend.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -22,17 +25,17 @@ config = get_config()
 
 class IPUsageTracker:
     """IP使用跟踪器，用于记录和统计代理IP使用情况"""
-    
+
     def __init__(self, log_file=None):
         """
         初始化IP使用跟踪器
-        
+
         Args:
             log_file: 记录IP使用情况的JSON文件路径，如果为None则使用配置中的默认路径
         """
         self.log_file = log_file if log_file else config.IP_USAGE_FILE
         self.usage_data = self._load_usage_data()
-        
+
     def _load_usage_data(self):
         """从文件加载IP使用数据，如果文件不存在则初始化空数据"""
         if os.path.exists(self.log_file):
@@ -43,7 +46,7 @@ class IPUsageTracker:
                 logger.error(f"加载IP使用数据失败: {e}")
                 return {'ips': {}, 'total_requests': 0, 'success_rate': 0}
         return {'ips': {}, 'total_requests': 0, 'success_rate': 0}
-        
+
     def _save_usage_data(self):
         """保存IP使用数据到文件"""
         try:
@@ -52,11 +55,11 @@ class IPUsageTracker:
                 json.dump(self.usage_data, f, indent=4, ensure_ascii=False)
         except Exception as e:
             logger.error(f"保存IP使用数据失败: {e}")
-            
+
     def record_usage(self, ip: str, success: bool):
         """
         记录IP使用情况
-        
+
         Args:
             ip: 使用的IP地址
             success: 是否成功使用
@@ -67,23 +70,23 @@ class IPUsageTracker:
                 'successful_uses': 0,
                 'last_used': None
             }
-            
+
         ip_data = self.usage_data['ips'][ip]
         ip_data['total_uses'] += 1
         if success:
             ip_data['successful_uses'] += 1
         ip_data['last_used'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        
+
         self.usage_data['total_requests'] += 1
         total_success = sum(ip['successful_uses'] for ip in self.usage_data['ips'].values())
         self.usage_data['success_rate'] = total_success / self.usage_data['total_requests'] if self.usage_data['total_requests'] > 0 else 0
-        
+
         self._save_usage_data()
-        
+
     def get_statistics(self):
         """
         获取IP使用统计信息
-        
+
         Returns:
             dict: 包含总IP数、总请求数、成功率和最常用IP的统计信息
         """
@@ -101,25 +104,34 @@ class IPUsageTracker:
 def get_current_ip(proxy_url: str = None) -> str:
     """
     获取当前使用的IP
-    
+
     Args:
         proxy_url: 代理服务器URL，如果为None则使用配置中的默认代理URL
-        
+
     Returns:
         str: 当前使用的IP地址，如果获取失败则返回None
     """
-    import requests
-    
-    # 如果没有提供代理URL，则使用配置中的默认URL
+    # 如果没有提供代理URL，则使用环境变量中的代理URL
     if proxy_url is None:
-        proxy_url = config.DEFAULT_PROXY_URL
-        
+        # 尝试从环境变量中获取代理URL
+        proxy_url = os.environ.get('PINZAN_API_URL', '')
+
+        # 如果环境变量中没有，则使用配置中的默认URL
+        if not proxy_url and hasattr(config, 'DEFAULT_PROXY_URL'):
+            proxy_url = config.DEFAULT_PROXY_URL
+
     if not proxy_url:
         logger.warning("未配置代理URL，无法获取当前IP")
         return None
-    
+
     try:
-        return requests.get(proxy_url).text.strip()
+        # 使用httpbin.org获取当前IP
+        response = requests.get('http://httpbin.org/ip', timeout=5)
+        if response.status_code == 200:
+            data = response.json()
+            if 'origin' in data:
+                return data['origin']
+        return None
     except Exception as e:
         logger.error(f"获取IP失败: {e}")
-        return None 
+        return None

--- a/backend/utils/proxy/__init__.py
+++ b/backend/utils/proxy/__init__.py
@@ -1,0 +1,19 @@
+"""
+----------------------------------------------------------------
+File name:                  __init__.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理模块初始化
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+from .base import BaseProxyProvider
+from .factory import ProxyFactory
+from .pool import ProxyPool
+from .utils import normalize_proxy_url, get_proxy_from_api, test_proxy, get_and_test_proxy, is_china_website, should_use_pinzan_proxy
+
+__all__ = ['BaseProxyProvider', 'ProxyFactory', 'ProxyPool', 'normalize_proxy_url', 'get_proxy_from_api', 'test_proxy', 'get_and_test_proxy', 'is_china_website', 'should_use_pinzan_proxy']

--- a/backend/utils/proxy/base.py
+++ b/backend/utils/proxy/base.py
@@ -1,0 +1,128 @@
+"""
+----------------------------------------------------------------
+File name:                  base.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理抽象基类，定义统一的代理接口
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+class BaseProxyProvider(ABC):
+    """
+    代理提供商抽象基类
+
+    定义统一的代理接口，所有具体的代理提供商实现都应继承此类
+    """
+
+    def __init__(self, api_key: str = None, **kwargs):
+        """
+        初始化代理提供商
+
+        Args:
+            api_key: API密钥（如果需要）
+            **kwargs: 其他参数
+        """
+        self.api_key = api_key
+        self.timeout = kwargs.get('timeout', 10)
+        self.max_retries = kwargs.get('max_retries', 3)
+
+        # 初始化提供商特定的配置
+        self._init_provider_config(**kwargs)
+
+    @abstractmethod
+    def _init_provider_config(self, **kwargs):
+        """
+        初始化提供商特定的配置
+
+        Args:
+            **kwargs: 配置参数
+        """
+        pass
+
+    @abstractmethod
+    def get_proxy(self, **kwargs) -> Dict[str, str]:
+        """
+        获取代理
+
+        Args:
+            **kwargs: 其他参数
+
+        Returns:
+            Dict[str, str]: 代理配置，格式为 {'http': 'http://ip:port', 'https': 'http://ip:port'}
+        """
+        pass
+
+    def get_proxies(self, count: int = 1, **kwargs) -> List[Dict[str, str]]:
+        """
+        获取多个代理
+
+        Args:
+            count: 代理数量
+            **kwargs: 其他参数
+
+        Returns:
+            List[Dict[str, str]]: 代理配置列表
+        """
+        # 默认实现，循环调用get_proxy方法
+        proxies = []
+        for _ in range(count):
+            proxy = self.get_proxy(**kwargs)
+            if proxy and proxy not in proxies:
+                proxies.append(proxy)
+        return proxies
+
+    def validate_proxy(self, proxy: Dict[str, str], test_url: str = 'https://www.baidu.com') -> bool:
+        """
+        验证代理是否可用
+
+        Args:
+            proxy: 代理配置
+            test_url: 测试URL
+
+        Returns:
+            bool: 代理是否可用
+        """
+        try:
+            response = requests.get(
+                test_url,
+                proxies=proxy,
+                timeout=self.timeout
+            )
+            return response.status_code == 200
+        except Exception as e:
+            logger.warning(f"代理验证失败: {proxy}, 错误: {str(e)}")
+            return False
+
+    def get_current_ip(self, proxy: Dict[str, str] = None) -> Optional[str]:
+        """
+        获取当前IP
+
+        Args:
+            proxy: 代理配置
+
+        Returns:
+            str: 当前IP，如果获取失败则返回None
+        """
+        try:
+            response = requests.get(
+                'http://httpbin.org/ip',
+                proxies=proxy,
+                timeout=self.timeout
+            )
+            if response.status_code == 200:
+                return response.json().get('origin')
+            return None
+        except Exception as e:
+            logger.warning(f"获取当前IP失败: {str(e)}")
+            return None

--- a/backend/utils/proxy/factory.py
+++ b/backend/utils/proxy/factory.py
@@ -1,0 +1,74 @@
+"""
+----------------------------------------------------------------
+File name:                  factory.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理工厂类，用于创建不同的代理提供商实例
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+from typing import Dict, Type, Any, Optional
+from .base import BaseProxyProvider
+
+logger = logging.getLogger(__name__)
+
+class ProxyFactory:
+    """
+    代理工厂类
+    
+    用于创建不同的代理提供商实例
+    """
+    
+    # 注册的提供商类
+    _providers: Dict[str, Type[BaseProxyProvider]] = {}
+    
+    @classmethod
+    def register_provider(cls, provider_name: str, provider_class: Type[BaseProxyProvider]):
+        """
+        注册代理提供商
+        
+        Args:
+            provider_name: 提供商名称
+            provider_class: 提供商类
+        """
+        cls._providers[provider_name] = provider_class
+        logger.info(f"注册代理提供商: {provider_name}")
+        
+    @classmethod
+    def create(cls, provider_name: str, api_key: str = None, **kwargs) -> Optional[BaseProxyProvider]:
+        """
+        创建代理提供商实例
+        
+        Args:
+            provider_name: 提供商名称
+            api_key: API密钥
+            **kwargs: 其他参数
+            
+        Returns:
+            BaseProxyProvider: 代理提供商实例，如果提供商不存在则返回None
+        """
+        if provider_name not in cls._providers:
+            logger.error(f"未知的代理提供商: {provider_name}")
+            return None
+            
+        try:
+            provider_class = cls._providers[provider_name]
+            return provider_class(api_key=api_key, **kwargs)
+        except Exception as e:
+            logger.error(f"创建代理提供商实例失败: {str(e)}")
+            return None
+    
+    @classmethod
+    def get_available_providers(cls) -> Dict[str, str]:
+        """
+        获取可用的代理提供商列表
+        
+        Returns:
+            Dict[str, str]: 提供商名称和描述的字典
+        """
+        return {name: provider.__doc__ for name, provider in cls._providers.items()}

--- a/backend/utils/proxy/manager.py
+++ b/backend/utils/proxy/manager.py
@@ -1,0 +1,299 @@
+"""
+----------------------------------------------------------------
+File name:                  manager.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理管理器，统一管理代理
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import os
+import json
+import time
+from typing import Dict, List, Any, Optional
+from .pool import ProxyPool
+from .factory import ProxyFactory
+from .base import BaseProxyProvider
+from ..env_loader import EnvLoader
+
+logger = logging.getLogger(__name__)
+
+class ProxyManager:
+    """
+    代理管理器
+
+    统一管理代理，支持多种代理源和轮换策略
+    """
+
+    def __init__(self, config_file: str = None, env_file: str = '.env', **kwargs):
+        """
+        初始化代理管理器
+
+        Args:
+            config_file: 配置文件路径
+            env_file: 环境变量文件路径
+            **kwargs: 其他参数
+        """
+        # 加载环境变量
+        EnvLoader.load_env(env_file)
+
+        self.config_file = config_file
+        self.config = {}
+        self.pool = ProxyPool(**kwargs)
+        self.enabled = kwargs.get('enabled', True)
+
+        # 加载配置
+        if config_file:
+            self.load_config()
+
+    def load_config(self):
+        """
+        加载配置
+
+        从配置文件加载配置
+        """
+        try:
+            if not self.config_file or not os.path.exists(self.config_file):
+                logger.warning(f"配置文件不存在: {self.config_file}")
+                return
+
+            with open(self.config_file, 'r', encoding='utf-8') as f:
+                self.config = json.load(f)
+
+            # 设置启用状态
+            self.enabled = self.config.get('enabled', True)
+
+            # 设置轮换策略
+            rotation_strategy = self.config.get('rotation_strategy', 'round_robin')
+            self.pool.rotation_strategy = rotation_strategy
+
+            # 加载提供商
+            providers = self.config.get('providers', [])
+            for provider_config in providers:
+                provider_type = provider_config.get('type')
+                if not provider_type:
+                    logger.warning("提供商配置缺少type字段")
+                    continue
+
+                # 创建提供商
+                provider = self._create_provider(provider_config)
+                if provider:
+                    self.pool.add_provider(provider)
+
+            logger.info(f"从配置文件加载了 {len(self.pool.providers)} 个代理提供商")
+
+        except Exception as e:
+            logger.error(f"加载配置失败: {str(e)}")
+
+    def save_config(self):
+        """
+        保存配置
+
+        将配置保存到配置文件
+        """
+        try:
+            if not self.config_file:
+                logger.warning("未指定配置文件路径")
+                return
+
+            # 更新配置
+            self.config['enabled'] = self.enabled
+            self.config['rotation_strategy'] = self.pool.rotation_strategy
+
+            # 创建目录
+            os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
+
+            # 保存配置
+            with open(self.config_file, 'w', encoding='utf-8') as f:
+                json.dump(self.config, f, indent=4, ensure_ascii=False)
+
+            logger.info(f"保存配置到文件: {self.config_file}")
+
+        except Exception as e:
+            logger.error(f"保存配置失败: {str(e)}")
+
+    def _create_provider(self, config: Dict[str, Any]) -> Optional[BaseProxyProvider]:
+        """
+        创建代理提供商
+
+        Args:
+            config: 提供商配置
+
+        Returns:
+            BaseProxyProvider: 代理提供商实例，如果创建失败则返回None
+        """
+        try:
+            provider_type = config.get('type')
+            api_key = config.get('api_key', '')
+
+            # 创建提供商
+            provider = ProxyFactory.create(provider_type, api_key, **config)
+
+            return provider
+
+        except Exception as e:
+            logger.error(f"创建代理提供商失败: {str(e)}")
+            return None
+
+    def add_provider(self, provider_type: str, api_key: str = None, **kwargs):
+        """
+        添加代理提供商
+
+        Args:
+            provider_type: 提供商类型
+            api_key: API密钥
+            **kwargs: 其他参数
+        """
+        try:
+            # 创建提供商
+            provider = ProxyFactory.create(provider_type, api_key, **kwargs)
+            if provider:
+                self.pool.add_provider(provider)
+
+                # 更新配置
+                if 'providers' not in self.config:
+                    self.config['providers'] = []
+
+                provider_config = {
+                    'type': provider_type,
+                    'api_key': api_key,
+                    **kwargs
+                }
+                self.config['providers'].append(provider_config)
+
+                # 保存配置
+                self.save_config()
+
+                logger.info(f"添加代理提供商: {provider_type}")
+            else:
+                logger.error(f"创建代理提供商失败: {provider_type}")
+
+        except Exception as e:
+            logger.error(f"添加代理提供商失败: {str(e)}")
+
+    def remove_provider(self, provider_type: str):
+        """
+        移除代理提供商
+
+        Args:
+            provider_type: 提供商类型
+        """
+        try:
+            # 移除提供商
+            for provider in self.pool.providers:
+                if provider.__class__.__name__ == f"{provider_type.capitalize()}Provider":
+                    self.pool.remove_provider(provider)
+
+                    # 更新配置
+                    if 'providers' in self.config:
+                        self.config['providers'] = [p for p in self.config['providers'] if p.get('type') != provider_type]
+
+                    # 保存配置
+                    self.save_config()
+
+                    logger.info(f"移除代理提供商: {provider_type}")
+                    break
+
+        except Exception as e:
+            logger.error(f"移除代理提供商失败: {str(e)}")
+
+    def get_proxy(self) -> Optional[Dict[str, str]]:
+        """
+        获取代理
+
+        如果启用了代理，则从代理池获取代理，否则返回None
+
+        Returns:
+            Dict[str, str]: 代理配置，如果未启用代理或没有可用代理则返回None
+        """
+        if not self.enabled:
+            logger.debug("代理未启用")
+            return None
+
+        return self.pool.get_proxy()
+
+    def validate_proxy(self, proxy: Dict[str, str], test_url: str = 'https://www.baidu.com') -> bool:
+        """
+        验证代理是否可用
+
+        Args:
+            proxy: 代理配置
+            test_url: 测试URL
+
+        Returns:
+            bool: 代理是否可用
+        """
+        # 随机选择一个提供商进行验证
+        if self.pool.providers:
+            provider = self.pool.providers[0]
+            return provider.validate_proxy(proxy, test_url)
+        return False
+
+    def get_current_ip(self, proxy: Dict[str, str] = None) -> Optional[str]:
+        """
+        获取当前IP
+
+        Args:
+            proxy: 代理配置
+
+        Returns:
+            str: 当前IP，如果获取失败则返回None
+        """
+        # 随机选择一个提供商获取当前IP
+        if self.pool.providers:
+            provider = self.pool.providers[0]
+            return provider.get_current_ip(proxy)
+        return None
+
+    def set_enabled(self, enabled: bool):
+        """
+        设置是否启用代理
+
+        Args:
+            enabled: 是否启用
+        """
+        self.enabled = enabled
+
+        # 更新配置
+        self.config['enabled'] = enabled
+
+        # 保存配置
+        self.save_config()
+
+        logger.info(f"设置代理启用状态: {enabled}")
+
+    def set_rotation_strategy(self, strategy: str):
+        """
+        设置轮换策略
+
+        Args:
+            strategy: 轮换策略
+        """
+        self.pool.rotation_strategy = strategy
+
+        # 更新配置
+        self.config['rotation_strategy'] = strategy
+
+        # 保存配置
+        self.save_config()
+
+        logger.info(f"设置代理轮换策略: {strategy}")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        获取统计信息
+
+        Returns:
+            Dict[str, Any]: 统计信息
+        """
+        return {
+            'enabled': self.enabled,
+            'rotation_strategy': self.pool.rotation_strategy,
+            'providers': [provider.__class__.__name__ for provider in self.pool.providers],
+            'proxies': len(self.pool.proxies)
+        }

--- a/backend/utils/proxy/pool.py
+++ b/backend/utils/proxy/pool.py
@@ -1,0 +1,203 @@
+"""
+----------------------------------------------------------------
+File name:                  pool.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理池管理类，管理多个代理
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import random
+from typing import Dict, List, Any, Optional
+from .base import BaseProxyProvider
+
+logger = logging.getLogger(__name__)
+
+class ProxyPool:
+    """
+    代理池管理类
+
+    管理多个代理，支持轮询、随机等轮换策略
+    """
+
+    def __init__(self, providers: List[BaseProxyProvider] = None, **kwargs):
+        """
+        初始化代理池
+
+        Args:
+            providers: 代理提供商列表
+            **kwargs: 其他参数
+        """
+        self.providers = providers or []
+        self.proxies = []
+        self.current_index = 0
+        self.rotation_strategy = kwargs.get('rotation_strategy', 'round_robin')
+        self.test_url = kwargs.get('test_url', 'https://www.baidu.com')
+
+    def add_provider(self, provider: BaseProxyProvider):
+        """
+        添加代理提供商
+
+        Args:
+            provider: 代理提供商
+        """
+        self.providers.append(provider)
+        logger.info(f"添加代理提供商: {provider.__class__.__name__}")
+
+    def remove_provider(self, provider: BaseProxyProvider):
+        """
+        移除代理提供商
+
+        Args:
+            provider: 代理提供商
+        """
+        if provider in self.providers:
+            self.providers.remove(provider)
+            logger.info(f"移除代理提供商: {provider.__class__.__name__}")
+
+    def add_proxy(self, proxy: Dict[str, str]):
+        """
+        添加代理
+
+        Args:
+            proxy: 代理配置
+        """
+        if proxy not in self.proxies:
+            self.proxies.append(proxy)
+            logger.debug(f"添加代理: {proxy}")
+
+    def remove_proxy(self, proxy: Dict[str, str]):
+        """
+        移除代理
+
+        Args:
+            proxy: 代理配置
+        """
+        if proxy in self.proxies:
+            self.proxies.remove(proxy)
+            logger.debug(f"移除代理: {proxy}")
+
+    def get_proxy(self) -> Optional[Dict[str, str]]:
+        """
+        获取代理
+
+        根据轮换策略获取代理
+
+        Returns:
+            Dict[str, str]: 代理配置，如果没有可用代理则返回None
+        """
+        # 如果代理池为空，尝试直接从提供商获取
+        if not self.proxies and self.providers:
+            for provider in self.providers:
+                try:
+                    proxy = provider.get_proxy()
+                    if proxy:
+                        return proxy
+                except Exception as e:
+                    logger.error(f"从提供商获取代理失败: {provider.__class__.__name__}, 错误: {str(e)}")
+
+            # 如果所有提供商都无法获取代理，尝试填充代理池
+            self.fill_pool()
+
+        # 如果仍然为空，返回None
+        if not self.proxies:
+            logger.warning("代理池为空，无法获取代理")
+            return None
+
+        # 根据轮换策略获取代理
+        if self.rotation_strategy == 'round_robin':
+            proxy = self._get_proxy_round_robin()
+        elif self.rotation_strategy == 'random':
+            proxy = self._get_proxy_random()
+        else:
+            logger.warning(f"未知的轮换策略: {self.rotation_strategy}，使用轮询策略")
+            proxy = self._get_proxy_round_robin()
+
+        return proxy
+
+    def _get_proxy_round_robin(self) -> Dict[str, str]:
+        """
+        轮询策略获取代理
+
+        Returns:
+            Dict[str, str]: 代理配置
+        """
+        proxy = self.proxies[self.current_index]
+        self.current_index = (self.current_index + 1) % len(self.proxies)
+        return proxy
+
+    def _get_proxy_random(self) -> Dict[str, str]:
+        """
+        随机策略获取代理
+
+        Returns:
+            Dict[str, str]: 代理配置
+        """
+        return random.choice(self.proxies)
+
+    def fill_pool(self):
+        """
+        填充代理池
+
+        从所有提供商获取代理
+        """
+        logger.info("填充代理池")
+
+        # 如果没有提供商，无法填充
+        if not self.providers:
+            logger.warning("没有代理提供商，无法填充代理池")
+            return
+
+        # 从每个提供商获取代理
+        for provider in self.providers:
+            try:
+                proxy = provider.get_proxy()
+                if proxy:
+                    self.add_proxy(proxy)
+            except Exception as e:
+                logger.error(f"从提供商获取代理失败: {provider.__class__.__name__}, 错误: {str(e)}")
+
+        logger.info(f"代理池填充完成，当前代理数量: {len(self.proxies)}")
+
+    def validate_all(self):
+        """
+        验证所有代理是否可用
+
+        移除不可用的代理
+        """
+        logger.info("验证所有代理")
+
+        valid_proxies = []
+        for proxy in self.proxies:
+            # 随机选择一个提供商进行验证
+            provider = random.choice(self.providers) if self.providers else None
+            if provider and provider.validate_proxy(proxy, self.test_url):
+                valid_proxies.append(proxy)
+            else:
+                logger.debug(f"代理不可用，移除: {proxy}")
+
+        self.proxies = valid_proxies
+        logger.info(f"代理验证完成，当前可用代理数量: {len(self.proxies)}")
+
+        # 如果没有可用代理，填充代理池
+        if not self.proxies:
+            logger.info("没有可用代理，填充代理池")
+            self.fill_pool()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        获取代理池统计信息
+
+        Returns:
+            Dict[str, Any]: 统计信息
+        """
+        return {
+            'total_proxies': len(self.proxies),
+            'providers': [provider.__class__.__name__ for provider in self.providers],
+            'rotation_strategy': self.rotation_strategy
+        }

--- a/backend/utils/proxy/providers/__init__.py
+++ b/backend/utils/proxy/providers/__init__.py
@@ -1,0 +1,22 @@
+"""
+----------------------------------------------------------------
+File name:                  __init__.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理提供商模块初始化
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+# 导入所有提供商
+from .pinzan_provider import PinzanProvider
+from .custom_provider import CustomProvider
+
+# 导出所有提供商
+__all__ = [
+    'PinzanProvider',
+    'CustomProvider'
+]

--- a/backend/utils/proxy/providers/custom_provider.py
+++ b/backend/utils/proxy/providers/custom_provider.py
@@ -1,0 +1,219 @@
+"""
+----------------------------------------------------------------
+File name:                  custom_provider.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                自定义代理提供商实现
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import requests
+import json
+import time
+import random
+from typing import Dict, List, Any, Optional
+from ..base import BaseProxyProvider
+from ..factory import ProxyFactory
+
+logger = logging.getLogger(__name__)
+
+class CustomProvider(BaseProxyProvider):
+    """
+    自定义代理提供商
+    
+    支持从文件、URL或固定列表获取代理
+    """
+    
+    def _init_provider_config(self, **kwargs):
+        """
+        初始化自定义代理提供商特定的配置
+        
+        Args:
+            **kwargs: 配置参数
+        """
+        # 代理源类型：file, url, list
+        self.source_type = kwargs.get('source_type', 'list')
+        
+        # 文件路径
+        self.file_path = kwargs.get('file_path', '')
+        
+        # URL
+        self.url = kwargs.get('url', '')
+        
+        # 代理列表
+        self.proxy_list = kwargs.get('proxy_list', [])
+        
+        # 缓存
+        self.cache_time = kwargs.get('cache_time', 300)  # 缓存时间（秒）
+        self.cache = []
+        self.last_fetch_time = 0
+        
+    def get_proxy(self, **kwargs) -> Dict[str, str]:
+        """
+        获取代理
+        
+        Args:
+            **kwargs: 其他参数
+            
+        Returns:
+            Dict[str, str]: 代理配置
+        """
+        # 确保缓存已填充
+        self._ensure_cache_filled()
+        
+        # 如果缓存为空，返回空代理
+        if not self.cache:
+            logger.warning("代理缓存为空，无法获取代理")
+            return {}
+            
+        # 随机选择一个代理
+        proxy = random.choice(self.cache)
+        return proxy
+    
+    def get_proxies(self, count: int = 1, **kwargs) -> List[Dict[str, str]]:
+        """
+        获取多个代理
+        
+        Args:
+            count: 代理数量
+            **kwargs: 其他参数
+            
+        Returns:
+            List[Dict[str, str]]: 代理配置列表
+        """
+        # 确保缓存已填充
+        self._ensure_cache_filled()
+        
+        # 如果缓存为空，返回空列表
+        if not self.cache:
+            logger.warning("代理缓存为空，无法获取代理")
+            return []
+            
+        # 随机选择多个代理
+        if len(self.cache) <= count:
+            return self.cache.copy()
+        else:
+            return random.sample(self.cache, count)
+    
+    def _ensure_cache_filled(self):
+        """
+        确保缓存已填充
+        
+        如果缓存为空或已过期，则重新填充
+        """
+        current_time = time.time()
+        if not self.cache or current_time - self.last_fetch_time > self.cache_time:
+            logger.debug("填充代理缓存")
+            self._fill_cache()
+            self.last_fetch_time = current_time
+    
+    def _fill_cache(self):
+        """
+        填充代理缓存
+        
+        根据源类型从不同来源获取代理
+        """
+        if self.source_type == 'file':
+            self._fill_from_file()
+        elif self.source_type == 'url':
+            self._fill_from_url()
+        elif self.source_type == 'list':
+            self._fill_from_list()
+        else:
+            logger.warning(f"未知的源类型: {self.source_type}")
+    
+    def _fill_from_file(self):
+        """从文件填充缓存"""
+        try:
+            if not self.file_path:
+                logger.error("未指定文件路径")
+                return
+                
+            with open(self.file_path, 'r') as f:
+                lines = f.readlines()
+                
+            self.cache = []
+            for line in lines:
+                line = line.strip()
+                if line:
+                    parts = line.split(':')
+                    if len(parts) >= 2:
+                        ip = parts[0]
+                        port = parts[1]
+                        proxy = {
+                            'http': f'http://{ip}:{port}',
+                            'https': f'http://{ip}:{port}'
+                        }
+                        self.cache.append(proxy)
+                        
+            logger.info(f"从文件加载了 {len(self.cache)} 个代理")
+                
+        except Exception as e:
+            logger.error(f"从文件加载代理失败: {str(e)}")
+    
+    def _fill_from_url(self):
+        """从URL填充缓存"""
+        try:
+            if not self.url:
+                logger.error("未指定URL")
+                return
+                
+            response = requests.get(self.url, timeout=self.timeout)
+            
+            if response.status_code == 200:
+                content = response.text
+                lines = content.splitlines()
+                
+                self.cache = []
+                for line in lines:
+                    line = line.strip()
+                    if line:
+                        parts = line.split(':')
+                        if len(parts) >= 2:
+                            ip = parts[0]
+                            port = parts[1]
+                            proxy = {
+                                'http': f'http://{ip}:{port}',
+                                'https': f'http://{ip}:{port}'
+                            }
+                            self.cache.append(proxy)
+                            
+                logger.info(f"从URL加载了 {len(self.cache)} 个代理")
+            else:
+                logger.error(f"从URL获取代理失败: {response.status_code}, {response.text}")
+                
+        except Exception as e:
+            logger.error(f"从URL加载代理失败: {str(e)}")
+    
+    def _fill_from_list(self):
+        """从列表填充缓存"""
+        try:
+            if not self.proxy_list:
+                logger.error("代理列表为空")
+                return
+                
+            self.cache = []
+            for proxy_str in self.proxy_list:
+                if proxy_str:
+                    parts = proxy_str.split(':')
+                    if len(parts) >= 2:
+                        ip = parts[0]
+                        port = parts[1]
+                        proxy = {
+                            'http': f'http://{ip}:{port}',
+                            'https': f'http://{ip}:{port}'
+                        }
+                        self.cache.append(proxy)
+                        
+            logger.info(f"从列表加载了 {len(self.cache)} 个代理")
+                
+        except Exception as e:
+            logger.error(f"从列表加载代理失败: {str(e)}")
+
+# 注册提供商
+ProxyFactory.register_provider('custom', CustomProvider)

--- a/backend/utils/proxy/providers/pinzan_provider.py
+++ b/backend/utils/proxy/providers/pinzan_provider.py
@@ -1,0 +1,307 @@
+"""
+----------------------------------------------------------------
+File name:                  pinzan_provider.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                品赞IP代理提供商实现
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/01: 初始创建
+                            2025/04/02: 根据官方API文档更新实现
+----------------------------------------------------------------
+"""
+
+import logging
+import requests
+import json
+import time
+import os
+import re
+from typing import Dict, List, Any, Optional
+from ..base import BaseProxyProvider
+from ..factory import ProxyFactory
+
+logger = logging.getLogger(__name__)
+
+class PinzanProvider(BaseProxyProvider):
+    """
+    品赞IP代理提供商
+
+    使用品赞IP API获取代理
+    官方文档: https://www.ipzan.com/help
+    """
+
+    def _init_provider_config(self, **kwargs):
+        """
+        初始化品赞IP特定的配置
+
+        Args:
+            **kwargs: 配置参数
+        """
+        # 从环境变量或配置中获取API URL
+        self.api_url = kwargs.get('api_url', os.environ.get('PINZAN_API_URL', ''))
+
+        # 代理协议
+        self.protocol = kwargs.get('protocol', os.environ.get('PINZAN_PROTOCOL', 'http'))
+
+        # 返回格式（根据API URL自动判断）
+        self.format = kwargs.get('format', '')
+        if not self.format:
+            if self.api_url and ('format=json' in self.api_url or '.json' in self.api_url):
+                self.format = 'json'
+            else:
+                self.format = 'txt'
+
+        # 输出调试信息
+        logger.debug(f"品赞IP返回格式: {self.format}")
+
+        # 缓存
+        self.cache_time = int(kwargs.get('cache_time', os.environ.get('PINZAN_CACHE_TIME', '60')))  # 缓存时间（秒）
+        self.cache = {}
+        self.last_fetch_time = 0
+
+    def get_proxy(self, **kwargs) -> Dict[str, str]:
+        """
+        获取代理
+
+        Args:
+            **kwargs: 其他参数
+
+        Returns:
+            Dict[str, str]: 代理配置
+        """
+        # 检查缓存
+        current_time = time.time()
+        if self.cache and current_time - self.last_fetch_time < self.cache_time:
+            logger.debug("使用缓存的代理")
+            return self.cache
+
+        # 检查API URL是否存在
+        if not self.api_url:
+            logger.error("未设置API URL")
+            return {}
+
+        try:
+            # 发送请求
+            response = requests.get(
+                self.api_url,
+                timeout=self.timeout
+            )
+
+            # 检查响应状态
+            if response.status_code == 200:
+                # 根据返回格式解析数据
+                if self.format == 'json':
+                    data = response.json()
+
+                    # 检查响应数据
+                    if data.get('code') == 0:
+                        proxy_list = data.get('data', {}).get('list', [])
+
+                        if proxy_list and len(proxy_list) > 0:
+                            proxy_data = proxy_list[0]
+                            ip = proxy_data.get('ip')
+                            port = proxy_data.get('port')
+
+                            if ip and port:
+                                # 如果有账号密码
+                                auth = ''
+                                if proxy_data.get('account') and proxy_data.get('password'):
+                                    auth = f"{proxy_data.get('account')}:{proxy_data.get('password')}@"
+
+                                # 根据协议构建代理URL
+                                proxy = {}
+
+                                # 根据协议类型构建代理URL
+                                if self.protocol.lower() == 'socks5':
+                                    # SOCKS5协议
+                                    proxy['http'] = f'socks5://{auth}{ip}:{port}'
+                                    proxy['https'] = f'socks5://{auth}{ip}:{port}'
+                                else:
+                                    # HTTP/HTTPS协议
+                                    proxy['http'] = f'http://{auth}{ip}:{port}'
+
+                                    # HTTPS代理
+                                    # 如果协议是https，则使用https协议
+                                    # 否则使用http协议（因为大多数HTTP代理也可以用于HTTPS请求）
+                                    if self.protocol.lower() == 'https':
+                                        proxy['https'] = f'https://{auth}{ip}:{port}'
+                                    else:
+                                        proxy['https'] = f'http://{auth}{ip}:{port}'
+
+                                # 更新缓存
+                                self.cache = proxy
+                                self.last_fetch_time = current_time
+
+                                return proxy
+                            else:
+                                logger.error(f"品赞IP响应缺少IP或端口: {data}")
+                        else:
+                            logger.error(f"品赞IP响应缺少代理列表: {data}")
+                    else:
+                        logger.error(f"品赞IP API错误: {data.get('message')}")
+                else:  # 处理txt格式
+                    # 检查是否是JSON格式的响应
+                    try:
+                        # 尝试解析JSON
+                        data = json.loads(response.text)
+
+                        # 如果是有效的JSON响应，则将其当作JSON格式处理
+                        if data.get('code') == 0 and data.get('data', {}).get('list'):
+                            logger.info("检测到JSON格式响应，切换为JSON格式处理")
+                            self.format = 'json'
+                            proxy_list = data.get('data', {}).get('list', [])
+
+                            if proxy_list and len(proxy_list) > 0:
+                                proxy_data = proxy_list[0]
+                                ip = proxy_data.get('ip')
+                                port = proxy_data.get('port')
+
+                                if ip and port:
+                                    # 如果有账号密码
+                                    auth = ''
+                                    if proxy_data.get('account') and proxy_data.get('password'):
+                                        auth = f"{proxy_data.get('account')}:{proxy_data.get('password')}@"
+
+                                    # 根据协议构建代理URL
+                                    proxy = {}
+
+                                    # 根据协议类型构建代理URL
+                                    if self.protocol.lower() == 'socks5':
+                                        # SOCKS5协议
+                                        proxy['http'] = f'socks5://{auth}{ip}:{port}'
+                                        proxy['https'] = f'socks5://{auth}{ip}:{port}'
+                                    else:
+                                        # HTTP/HTTPS协议
+                                        proxy['http'] = f'http://{auth}{ip}:{port}'
+
+                                        # HTTPS代理
+                                        # 如果协议是https，则使用https协议
+                                        # 否则使用http协议（因为大多数HTTP代理也可以用于HTTPS请求）
+                                        if self.protocol.lower() == 'https':
+                                            proxy['https'] = f'https://{auth}{ip}:{port}'
+                                        else:
+                                            proxy['https'] = f'http://{auth}{ip}:{port}'
+
+                                    # 更新缓存
+                                    self.cache = proxy
+                                    self.last_fetch_time = current_time
+
+                                    return proxy
+
+                            logger.error(f"品赞IP响应缺少有效的代理信息: {data}")
+                            return {}
+                        elif data.get('code') != 0:
+                            logger.error(f"品赞IP API错误: {data.get('message')}")
+                            return {}
+                    except json.JSONDecodeError:
+                        # 不是JSON格式，继续处理TXT格式
+                        pass
+
+                    # 处理TXT格式
+                    lines = response.text.strip().split('\n')
+                    if lines and len(lines) > 0:
+                        line = lines[0].strip()
+
+                        # 检查是否包含错误信息
+                        if 'error' in line.lower() or ('code' in line.lower() and 'status' in line.lower()):
+                            logger.error(f"品赞IP响应错误: {line}")
+                            return {}
+
+                        # 解析代理格式
+                        parts = line.split(':')
+                        if len(parts) >= 2:
+                            ip = parts[0]
+                            port = parts[1]
+
+                            # 检查IP和端口是否有效
+                            if not self._is_valid_ip(ip) or not port.isdigit():
+                                logger.error(f"品赞IP响应包含无效的IP或端口: {line}")
+                                return {}
+
+                            # 如果有账号密码
+                            auth = ''
+                            if len(parts) >= 4:
+                                username = parts[2]
+                                password = parts[3]
+                                auth = f'{username}:{password}@'
+
+                            # 根据协议构建代理URL
+                            proxy = {}
+
+                            # 根据协议类型构建代理URL
+                            if self.protocol.lower() == 'socks5':
+                                # SOCKS5协议
+                                proxy['http'] = f'socks5://{auth}{ip}:{port}'
+                                proxy['https'] = f'socks5://{auth}{ip}:{port}'
+                            else:
+                                # HTTP/HTTPS协议
+                                proxy['http'] = f'http://{auth}{ip}:{port}'
+
+                                # HTTPS代理
+                                # 如果协议是https，则使用https协议
+                                # 否则使用http协议（因为大多数HTTP代理也可以用于HTTPS请求）
+                                if self.protocol.lower() == 'https':
+                                    proxy['https'] = f'https://{auth}{ip}:{port}'
+                                else:
+                                    proxy['https'] = f'http://{auth}{ip}:{port}'
+
+                            # 更新缓存
+                            self.cache = proxy
+                            self.last_fetch_time = current_time
+
+                            return proxy
+                        else:
+                            logger.error(f"品赞IP响应格式错误: {line}")
+                    else:
+                        logger.error("品赞IP响应为空")
+            else:
+                logger.error(f"品赞IP API请求失败: {response.status_code}, {response.text}")
+
+            # 如果获取失败，返回缓存（如果有）
+            if self.cache:
+                logger.warning("获取新代理失败，使用缓存的代理")
+                return self.cache
+
+            # 如果没有缓存，返回空代理
+            return {}
+
+        except Exception as e:
+            logger.error(f"品赞IP获取代理失败: {str(e)}")
+
+            # 如果获取失败，返回缓存（如果有）
+            if self.cache:
+                logger.warning("获取新代理失败，使用缓存的代理")
+                return self.cache
+
+            # 如果没有缓存，返回空代理
+            return {}
+
+    def _is_valid_ip(self, ip: str) -> bool:
+        """
+        验证IP是否有效
+
+        Args:
+            ip: IP地址
+
+        Returns:
+            bool: IP是否有效
+        """
+        # 简单的IP格式验证
+        pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+        if not re.match(pattern, ip):
+            return False
+
+        # 验证每个数字是否在有效范围内
+        parts = ip.split('.')
+        for part in parts:
+            if not part.isdigit() or int(part) > 255:
+                return False
+
+        return True
+
+    # 使用基类中的get_proxies方法的默认实现
+
+# 注册提供商
+ProxyFactory.register_provider('pinzan', PinzanProvider)

--- a/backend/utils/proxy/sources/__init__.py
+++ b/backend/utils/proxy/sources/__init__.py
@@ -1,0 +1,22 @@
+"""
+----------------------------------------------------------------
+File name:                  __init__.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                代理源模块初始化
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+# 导入所有代理源
+from .file_source import FileProxySource
+from .api_source import APIProxySource
+
+# 导出所有代理源
+__all__ = [
+    'FileProxySource',
+    'APIProxySource'
+]

--- a/backend/utils/proxy/sources/api_source.py
+++ b/backend/utils/proxy/sources/api_source.py
@@ -1,0 +1,253 @@
+"""
+----------------------------------------------------------------
+File name:                  api_source.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                API代理源实现
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import requests
+import json
+import time
+import random
+from typing import Dict, List, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class APIProxySource:
+    """
+    API代理源
+    
+    从API获取代理
+    """
+    
+    def __init__(self, api_url: str, **kwargs):
+        """
+        初始化API代理源
+        
+        Args:
+            api_url: API URL
+            **kwargs: 其他参数
+        """
+        self.api_url = api_url
+        self.api_key = kwargs.get('api_key', '')
+        self.timeout = kwargs.get('timeout', 10)
+        self.max_retries = kwargs.get('max_retries', 3)
+        self.cache_time = kwargs.get('cache_time', 300)  # 缓存时间（秒）
+        self.params = kwargs.get('params', {})
+        self.headers = kwargs.get('headers', {})
+        
+        # 缓存
+        self.cache = []
+        self.last_fetch_time = 0
+        
+    def get_proxy(self) -> Optional[Dict[str, str]]:
+        """
+        获取代理
+        
+        随机选择一个代理
+        
+        Returns:
+            Dict[str, str]: 代理配置，如果没有可用代理则返回None
+        """
+        # 确保缓存已填充
+        self._ensure_cache_filled()
+        
+        # 如果缓存为空，返回None
+        if not self.cache:
+            logger.warning("代理缓存为空，无法获取代理")
+            return None
+            
+        # 随机选择一个代理
+        return random.choice(self.cache)
+        
+    def get_proxies(self, count: int = 1) -> List[Dict[str, str]]:
+        """
+        获取多个代理
+        
+        随机选择多个代理
+        
+        Args:
+            count: 代理数量
+            
+        Returns:
+            List[Dict[str, str]]: 代理配置列表
+        """
+        # 确保缓存已填充
+        self._ensure_cache_filled()
+        
+        # 如果缓存为空，返回空列表
+        if not self.cache:
+            logger.warning("代理缓存为空，无法获取代理")
+            return []
+            
+        # 随机选择多个代理
+        if len(self.cache) <= count:
+            return self.cache.copy()
+        else:
+            return random.sample(self.cache, count)
+            
+    def _ensure_cache_filled(self):
+        """
+        确保缓存已填充
+        
+        如果缓存为空或已过期，则重新填充
+        """
+        current_time = time.time()
+        if not self.cache or current_time - self.last_fetch_time > self.cache_time:
+            logger.debug("填充代理缓存")
+            self._fill_cache()
+            self.last_fetch_time = current_time
+            
+    def _fill_cache(self):
+        """
+        填充缓存
+        
+        从API获取代理
+        """
+        try:
+            # 构建请求参数
+            params = self.params.copy()
+            if self.api_key:
+                params['api_key'] = self.api_key
+                
+            # 构建请求头
+            headers = self.headers.copy()
+            
+            # 发送请求
+            for retry in range(self.max_retries):
+                try:
+                    response = requests.get(
+                        self.api_url,
+                        params=params,
+                        headers=headers,
+                        timeout=self.timeout
+                    )
+                    
+                    # 检查响应状态
+                    if response.status_code == 200:
+                        # 尝试解析JSON
+                        try:
+                            data = response.json()
+                            self._parse_json_response(data)
+                            break
+                        except json.JSONDecodeError:
+                            # 如果不是JSON，尝试解析文本
+                            self._parse_text_response(response.text)
+                            break
+                    else:
+                        logger.warning(f"API请求失败: {response.status_code}, {response.text}")
+                        time.sleep(1)
+                except Exception as e:
+                    logger.warning(f"API请求异常: {str(e)}")
+                    time.sleep(1)
+                    
+            logger.info(f"从API加载了 {len(self.cache)} 个代理")
+                
+        except Exception as e:
+            logger.error(f"从API加载代理失败: {str(e)}")
+            
+    def _parse_json_response(self, data: Dict[str, Any]):
+        """
+        解析JSON响应
+        
+        Args:
+            data: JSON数据
+        """
+        # 清空缓存
+        self.cache = []
+        
+        # 尝试不同的JSON格式
+        if isinstance(data, list):
+            # 如果是列表，尝试解析每个元素
+            for item in data:
+                if isinstance(item, dict):
+                    # 尝试常见的字段名
+                    ip = item.get('ip') or item.get('host') or item.get('addr')
+                    port = item.get('port')
+                    
+                    if ip and port:
+                        proxy = {
+                            'http': f'http://{ip}:{port}',
+                            'https': f'http://{ip}:{port}'
+                        }
+                        self.cache.append(proxy)
+                elif isinstance(item, str):
+                    # 如果是字符串，尝试解析为 ip:port 格式
+                    parts = item.split(':')
+                    if len(parts) >= 2:
+                        ip = parts[0]
+                        port = parts[1]
+                        proxy = {
+                            'http': f'http://{ip}:{port}',
+                            'https': f'http://{ip}:{port}'
+                        }
+                        self.cache.append(proxy)
+        elif isinstance(data, dict):
+            # 如果是字典，尝试解析常见的结构
+            if 'data' in data and isinstance(data['data'], list):
+                # 如果有data字段且为列表，递归解析
+                self._parse_json_response(data['data'])
+            elif 'proxies' in data and isinstance(data['proxies'], list):
+                # 如果有proxies字段且为列表，递归解析
+                self._parse_json_response(data['proxies'])
+            elif 'result' in data and isinstance(data['result'], list):
+                # 如果有result字段且为列表，递归解析
+                self._parse_json_response(data['result'])
+            else:
+                # 尝试常见的字段名
+                ip = data.get('ip') or data.get('host') or data.get('addr')
+                port = data.get('port')
+                
+                if ip and port:
+                    proxy = {
+                        'http': f'http://{ip}:{port}',
+                        'https': f'http://{ip}:{port}'
+                    }
+                    self.cache.append(proxy)
+                    
+    def _parse_text_response(self, text: str):
+        """
+        解析文本响应
+        
+        Args:
+            text: 文本数据
+        """
+        # 清空缓存
+        self.cache = []
+        
+        # 按行分割
+        lines = text.splitlines()
+        
+        for line in lines:
+            line = line.strip()
+            if line:
+                # 尝试解析为 ip:port 格式
+                parts = line.split(':')
+                if len(parts) >= 2:
+                    ip = parts[0]
+                    port = parts[1]
+                    proxy = {
+                        'http': f'http://{ip}:{port}',
+                        'https': f'http://{ip}:{port}'
+                    }
+                    self.cache.append(proxy)
+                    
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        获取统计信息
+        
+        Returns:
+            Dict[str, Any]: 统计信息
+        """
+        return {
+            'total_proxies': len(self.cache),
+            'api_url': self.api_url,
+            'last_fetch_time': self.last_fetch_time
+        }

--- a/backend/utils/proxy/sources/file_source.py
+++ b/backend/utils/proxy/sources/file_source.py
@@ -1,0 +1,161 @@
+"""
+----------------------------------------------------------------
+File name:                  file_source.py
+Author:                     Ignorant-lu
+Date created:               2025/04/01
+Description:                文件代理源实现
+----------------------------------------------------------------
+
+Changed history:            
+                            2025/04/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import os
+import random
+from typing import Dict, List, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class FileProxySource:
+    """
+    文件代理源
+    
+    从文件加载代理
+    """
+    
+    def __init__(self, file_path: str, **kwargs):
+        """
+        初始化文件代理源
+        
+        Args:
+            file_path: 文件路径
+            **kwargs: 其他参数
+        """
+        self.file_path = file_path
+        self.encoding = kwargs.get('encoding', 'utf-8')
+        self.proxies = []
+        self.load_proxies()
+        
+    def load_proxies(self):
+        """
+        加载代理
+        
+        从文件加载代理
+        """
+        try:
+            if not os.path.exists(self.file_path):
+                logger.error(f"代理文件不存在: {self.file_path}")
+                return
+                
+            with open(self.file_path, 'r', encoding=self.encoding) as f:
+                lines = f.readlines()
+                
+            self.proxies = []
+            for line in lines:
+                line = line.strip()
+                if line:
+                    parts = line.split(':')
+                    if len(parts) >= 2:
+                        ip = parts[0]
+                        port = parts[1]
+                        proxy = {
+                            'http': f'http://{ip}:{port}',
+                            'https': f'http://{ip}:{port}'
+                        }
+                        self.proxies.append(proxy)
+                        
+            logger.info(f"从文件加载了 {len(self.proxies)} 个代理")
+                
+        except Exception as e:
+            logger.error(f"从文件加载代理失败: {str(e)}")
+            
+    def get_proxy(self) -> Optional[Dict[str, str]]:
+        """
+        获取代理
+        
+        随机选择一个代理
+        
+        Returns:
+            Dict[str, str]: 代理配置，如果没有可用代理则返回None
+        """
+        if not self.proxies:
+            logger.warning("代理列表为空，无法获取代理")
+            return None
+            
+        return random.choice(self.proxies)
+        
+    def get_proxies(self, count: int = 1) -> List[Dict[str, str]]:
+        """
+        获取多个代理
+        
+        随机选择多个代理
+        
+        Args:
+            count: 代理数量
+            
+        Returns:
+            List[Dict[str, str]]: 代理配置列表
+        """
+        if not self.proxies:
+            logger.warning("代理列表为空，无法获取代理")
+            return []
+            
+        if len(self.proxies) <= count:
+            return self.proxies.copy()
+        else:
+            return random.sample(self.proxies, count)
+            
+    def add_proxy(self, proxy: Dict[str, str]):
+        """
+        添加代理
+        
+        Args:
+            proxy: 代理配置
+        """
+        if proxy not in self.proxies:
+            self.proxies.append(proxy)
+            logger.debug(f"添加代理: {proxy}")
+            
+    def remove_proxy(self, proxy: Dict[str, str]):
+        """
+        移除代理
+        
+        Args:
+            proxy: 代理配置
+        """
+        if proxy in self.proxies:
+            self.proxies.remove(proxy)
+            logger.debug(f"移除代理: {proxy}")
+            
+    def save_proxies(self):
+        """
+        保存代理
+        
+        将代理保存到文件
+        """
+        try:
+            with open(self.file_path, 'w', encoding=self.encoding) as f:
+                for proxy in self.proxies:
+                    http_proxy = proxy.get('http', '')
+                    if http_proxy.startswith('http://'):
+                        http_proxy = http_proxy[7:]
+                    f.write(f"{http_proxy}\n")
+                    
+            logger.info(f"保存了 {len(self.proxies)} 个代理到文件")
+                
+        except Exception as e:
+            logger.error(f"保存代理到文件失败: {str(e)}")
+            
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        获取统计信息
+        
+        Returns:
+            Dict[str, Any]: 统计信息
+        """
+        return {
+            'total_proxies': len(self.proxies),
+            'file_path': self.file_path
+        }

--- a/backend/utils/proxy/utils.py
+++ b/backend/utils/proxy/utils.py
@@ -1,0 +1,588 @@
+"""
+----------------------------------------------------------------
+File name:                  utils.py
+Author:                     Ignorant-lu
+Date created:               2025/04/18
+Description:                代理工具函数
+----------------------------------------------------------------
+
+Changed history:
+                            2025/04/18: 初始创建
+----------------------------------------------------------------
+"""
+
+import logging
+import requests
+import time
+import os
+import re
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+
+# 获取日志记录器
+logger = logging.getLogger(__name__)
+
+def is_china_website(url):
+    """
+    检查URL是否为国内网站
+
+    通过域名后缀和常见国内网站域名判断
+
+    Args:
+        url (str): 要检查的URL
+
+    Returns:
+        bool: 如果是国内网站返回True，否则返回False
+    """
+
+    # 如果是本地地址或内网地址，返回True
+    if url.startswith('http://localhost') or url.startswith('http://127.0.0.1'):
+        return True
+    if not url:
+        return False
+
+    # 解析URL获取域名
+    parsed_url = urlparse(url)
+    domain = parsed_url.netloc.lower()
+
+    # 如果是IP地址，无法判断，返回False
+    if re.match(r'^\d+\.\d+\.\d+\.\d+$', domain):
+        return False
+
+    # 常见国内网站域名
+    china_domains = [
+        'baidu.com', 'qq.com', '163.com', 'sina.com.cn', 'sohu.com',
+        'taobao.com', 'jd.com', 'weibo.com', 'aliyun.com', 'tencent.com',
+        'bilibili.com', 'zhihu.com', 'douban.com', 'iqiyi.com', 'youku.com',
+        'csdn.net', 'cnblogs.com', '126.com', 'ctrip.com', 'meituan.com',
+        'wjx.cn', 'wjx.top'  # 问卷星域名
+    ]
+
+    # 检查是否为常见国内网站
+    for china_domain in china_domains:
+        if domain.endswith(china_domain):
+            return True
+
+    # 检查是否为中国域名
+    china_tlds = ['.cn', '.com.cn', '.net.cn', '.org.cn', '.gov.cn', '.edu.cn']
+    for tld in china_tlds:
+        if domain.endswith(tld):
+            return True
+
+    # 默认返回False
+    return False
+
+def normalize_proxy_url(proxy_url):
+    """
+    标准化代理URL
+
+    将代理URL标准化为HTTP协议，并确保协议参数和格式参数正确
+
+    Args:
+        proxy_url (str): 代理URL
+
+    Returns:
+        str: 标准化后的代理URL
+    """
+    if not proxy_url:
+        return None
+
+    # 记录原始URL
+    logger.info(f"标准化代理URL: {proxy_url}")
+
+    # 解析URL
+    parsed_url = urlparse(proxy_url)
+
+    # 确保使用HTTP协议
+    if parsed_url.scheme == 'https':
+        parsed_url = parsed_url._replace(scheme='http')
+        logger.info(f"将HTTPS协议更改为HTTP: {urlunparse(parsed_url)}")
+
+    # 如果是品赞API URL，确保所有必要参数正确
+    if 'ipzan.com' in parsed_url.netloc:
+        # 警告用户品赞代理只适用于国内网站
+        logger.warning("注意: 品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站")
+        # 解析查询参数
+        query_params = parse_qs(parsed_url.query)
+
+        # 检查必需参数
+        if 'no' not in query_params:
+            logger.error(f"缺少必需参数: no (套餐编号/账号)")
+            return None
+
+        # 检查模式参数
+        if 'mode' in query_params:
+            mode = query_params['mode'][0]
+            # 如果是auth模式，需要检查secret参数
+            if mode == 'auth' and 'secret' not in query_params:
+                logger.error(f"使用auth模式时缺少secret参数")
+                return None
+        else:
+            # 默认使用whitelist模式
+            query_params['mode'] = ['whitelist']
+            logger.info(f"添加参数: mode=whitelist")
+
+        # 添加其他参数的默认值
+        default_params = {
+            'protocol': '1',  # HTTP/HTTPS协议，1表示HTTP/HTTPS，3表示SOCKS5
+            'format': 'json',  # 返回格式，可选json或txt
+            'num': '1',  # 提取数量，默认为1
+            'minute': '5',  # 占用时长，可选值为3、5、10、15、30
+            'pool': 'ordinary'  # IP类型，可选值为quality(优质IP)或ordinary(普通IP)
+        }
+
+        for param, default_value in default_params.items():
+            if param not in query_params:
+                query_params[param] = [default_value]
+                logger.info(f"添加参数: {param}={default_value}")
+
+        # 重新构建查询字符串
+        query_string = urlencode(query_params, doseq=True)
+        parsed_url = parsed_url._replace(query=query_string)
+
+    # 重新构建URL
+    normalized_url = urlunparse(parsed_url)
+    logger.info(f"标准化后的代理URL: {normalized_url}")
+
+    return normalized_url
+
+def get_proxy_from_api(proxy_url):
+    """
+    从API获取代理
+
+    从代理API获取代理IP和端口
+
+    Args:
+        proxy_url (str): 代理API URL
+
+    Returns:
+        dict: 代理配置，格式为 {'http': 'http://...', 'https': 'http://...'}
+        None: 如果获取失败
+    """
+    if not proxy_url:
+        return None
+
+    # 标准化代理URL
+    proxy_url = normalize_proxy_url(proxy_url)
+    if not proxy_url:
+        return None
+
+    try:
+        # 发送请求获取代理
+        logger.info(f"尝试从API获取代理: {proxy_url}")
+        api_response = requests.get(proxy_url, timeout=10, verify=False)
+
+        if api_response.status_code == 200:
+            logger.info(f"API响应: {api_response.text[:200]}...")
+
+            # 尝试解析JSON响应
+            try:
+                data = api_response.json()
+                logger.info(f"解析的JSON数据: {data}")
+
+                # 处理品赞API响应
+                if 'ipzan.com' in proxy_url:
+                    logger.info(f"品赞API响应数据: {data}")
+
+                    # 处理成功响应
+                    if data.get('code') == 0:
+                        # 检查数据格式
+                        ip = None
+                        port = None
+                        account = None
+                        password = None
+
+                        # 处理不同的数据结构
+                        if data.get('data'):
+                            # 品赞API标准格式: {"data": {"list": [{"ip": "...", "port": "...", "account": "...", "password": "..."}]}}
+                            if isinstance(data.get('data'), dict) and data.get('data', {}).get('list'):
+                                proxy_list = data['data']['list']
+                                if proxy_list and len(proxy_list) > 0:
+                                    proxy_info = proxy_list[0]
+                                    ip = proxy_info.get('ip')
+                                    port = proxy_info.get('port')
+                                    account = proxy_info.get('account')
+                                    password = proxy_info.get('password')
+                                    # 获取其他信息用于日志
+                                    expired_time = proxy_info.get('expired')  # 过期时间
+                                    net_type = proxy_info.get('net')  # 网络类型（电信、联通等）
+                                    logger.info(f"从品赞API解析代理信息: IP={ip}, 端口={port}, 账号={account}, 密码={password}, 网络={net_type}")
+                                    if expired_time:
+                                        # 转换成时间格式
+                                        import datetime
+                                        expired_date = datetime.datetime.fromtimestamp(expired_time/1000)
+                                        logger.info(f"代理过期时间: {expired_date.strftime('%Y-%m-%d %H:%M:%S')}")
+
+                            # 格式2: {"data": [{"ip": "...", "port": "..."}]}
+                            elif isinstance(data.get('data'), list) and len(data.get('data')) > 0:
+                                proxy_info = data['data'][0]
+                                ip = proxy_info.get('ip')
+                                port = proxy_info.get('port')
+                                account = proxy_info.get('account')
+                                password = proxy_info.get('password')
+                                logger.info(f"从格式2解析代理信息: IP={ip}, 端口={port}")
+
+                            # 格式3: {"data": {"ip": "...", "port": "..."}}
+                            elif isinstance(data.get('data'), dict) and 'ip' in data.get('data'):
+                                proxy_info = data['data']
+                                ip = proxy_info.get('ip')
+                                port = proxy_info.get('port')
+                                account = proxy_info.get('account')
+                                password = proxy_info.get('password')
+                                logger.info(f"从格式3解析代理信息: IP={ip}, 端口={port}")
+
+                        # 直接在根级别包含IP和端口
+                        elif 'ip' in data and 'port' in data:
+                            ip = data.get('ip')
+                            port = data.get('port')
+                            account = data.get('account')
+                            password = data.get('password')
+                            logger.info(f"从根级别解析代理信息: IP={ip}, 端口={port}")
+
+                        # 记录解析到的代理信息
+                        if ip and port:
+                            logger.info(f"代理IP: {ip}")
+                            logger.info(f"代理端口: {port}")
+                            if account:
+                                logger.info(f"账号: {account}")
+                            if password:
+                                logger.info(f"密码: {password}")
+
+                            # 构建代理URL
+                            if account and password:
+                                proxy_str = f"http://{account}:{password}@{ip}:{port}"
+                            else:
+                                proxy_str = f"http://{ip}:{port}"
+
+                            logger.info(f"代理URL: {proxy_str}")
+                            return {'http': proxy_str, 'https': proxy_str}
+                        else:
+                            logger.warning(f"未找到代理IP或端口")
+                    # 处理错误响应
+                    elif data.get('code') == -1:
+                        error_message = data.get('message', '')
+                        logger.warning(f"品赞API返回错误: {error_message}")
+
+                        # 定义错误类型和对应的处理方式
+                        error_types = {
+                            '白名单': 'whitelist_error',  # 白名单错误
+                            '套餐余量不足': 'package_error',  # 套餐错误
+                            '套餐已过期': 'package_error',
+                            '套餐被禁用': 'package_error',
+                            '提取频率过快': 'rate_limit_error',  # 频率限制
+                            '余额不足': 'balance_error',  # 余额不足
+                            '用户被禁用': 'user_error',  # 用户错误
+                            '身份未认证': 'auth_error',  # 认证错误
+                            'secret密匙错误': 'auth_error',
+                            '账号密码错误': 'auth_error'
+                        }
+
+                        # 确定错误类型
+                        error_type = None
+                        for key, value in error_types.items():
+                            if key in error_message:
+                                error_type = value
+                                break
+
+                        # 根据错误类型处理
+                        if error_type == 'whitelist_error':
+                            # 如果是白名单错误，尝试切换到auth模式
+                            parsed_url = urlparse(proxy_url)
+                            query_params = parse_qs(parsed_url.query)
+
+                            # 检查当前模式
+                            current_mode = query_params.get('mode', [''])[0]
+
+                            if current_mode != 'auth':
+                                # 切换到auth模式
+                                query_params['mode'] = ['auth']
+
+                                # 确保有secret参数
+                                if 'secret' not in query_params and 'no' in query_params:
+                                    # 使用账号作为密码，实际应该使用正确的密码
+                                    # 如果环境变量中有密码，优先使用环境变量中的密码
+                                    secret = os.environ.get('PINZAN_SECRET', query_params['no'][0])
+                                    query_params['secret'] = [secret]
+                                    logger.info(f"添加secret参数: {secret}")
+
+                                # 重新构建查询字符串
+                                query_string = urlencode(query_params, doseq=True)
+                                parsed_url = parsed_url._replace(query=query_string)
+                                new_url = urlunparse(parsed_url)
+
+                                logger.info(f"尝试切换到auth模式: {new_url}")
+                                return get_proxy_from_api(new_url)  # 递归调用自身
+                            else:
+                                # 如果已经是auth模式但仍然失败
+                                logger.warning(f"已经使用auth模式，但仍然返回错误，可能是短时间内多次请求触发了限制")
+                        elif error_type == 'rate_limit_error':
+                            # 如果是频率限制，等待一段时间再重试
+                            logger.warning("品赞API提取频率过快，等待几秒后再重试")
+                            time.sleep(3)  # 等待3秒
+                            return get_proxy_from_api(proxy_url)  # 递归调用自身
+                        elif error_type == 'balance_error':
+                            # 如果是余额不足，无法继续
+                            logger.error("品赞API余额不足，请充值后再使用")
+                            return None
+                        elif error_type == 'package_error':
+                            # 套餐相关错误
+                            logger.warning(f"品赞API返回套餐错误: {error_message}")
+                        elif error_type == 'user_error':
+                            # 用户错误
+                            logger.warning(f"品赞API返回用户错误: {error_message}")
+                        elif error_type == 'auth_error':
+                            # 认证错误
+                            logger.warning(f"品赞API返回认证错误: {error_message}")
+                        else:
+                            # 其他错误
+                            logger.warning(f"品赞API返回未知错误: {error_message}")
+
+                        # 尝试使用环境变量中的代理
+                        http_proxy = os.environ.get('HTTP_PROXY')
+                        https_proxy = os.environ.get('HTTPS_PROXY') or os.environ.get('HTTP_PROXY')
+
+                        if http_proxy:
+                            logger.info(f"尝试使用环境变量中的代理: HTTP_PROXY={http_proxy}, HTTPS_PROXY={https_proxy}")
+                            # 测试环境变量中的代理是否可用
+                            env_proxies = {
+                                'http': http_proxy,
+                                'https': https_proxy
+                            }
+                            if test_proxy(env_proxies, timeout=2):
+                                logger.info(f"环境变量代理测试成功: {env_proxies}")
+                                return env_proxies
+
+                        # 直接返回空结果，系统将降级使用直接连接
+                        logger.warning(f"无法获取代理，系统将降级使用直接连接")
+                        return None
+                    else:
+                        logger.warning(f"API返回错误: {data}")
+                else:
+                    logger.warning(f"API返回错误: {data}")
+            except ValueError:
+                # 如果不是JSON，尝试解析TXT格式
+                text_response = api_response.text.strip()
+                logger.info(f"收到文本响应: {text_response[:200]}...")
+
+                # 尝试不同的分隔符
+                for separator in ['\n', '\r\n', ';', ',']:
+                    lines = text_response.split(separator)
+                    if len(lines) > 0:
+                        # 处理第一行
+                        first_line = lines[0].strip()
+                        logger.info(f"尝试解析行: {first_line}")
+
+                        # 尝试解析IP:PORT格式
+                        if ':' in first_line:
+                            parts = first_line.split(':')
+                            if len(parts) >= 2:
+                                ip = parts[0].strip()
+                                port = parts[1].strip()
+
+                                # 检查是否有账号密码
+                                if len(parts) >= 4:  # IP:PORT:ACCOUNT:PASSWORD
+                                    account = parts[2].strip()
+                                    password = parts[3].strip()
+                                    proxy_str = f"http://{account}:{password}@{ip}:{port}"
+                                else:
+                                    proxy_str = f"http://{ip}:{port}"
+
+                                logger.info(f"从文本响应中解析到代理: {proxy_str}")
+                                return {'http': proxy_str, 'https': proxy_str}
+
+                        # 尝试解析空格分隔的格式 (IP PORT ACCOUNT PASSWORD)
+                        parts = first_line.split()
+                        if len(parts) >= 2:
+                            ip = parts[0].strip()
+                            port = parts[1].strip()
+
+                            # 检查是否有账号密码
+                            if len(parts) >= 4:
+                                account = parts[2].strip()
+                                password = parts[3].strip()
+                                proxy_str = f"http://{account}:{password}@{ip}:{port}"
+                            else:
+                                proxy_str = f"http://{ip}:{port}"
+
+                            logger.info(f"从文本响应中解析到代理: {proxy_str}")
+                            return {'http': proxy_str, 'https': proxy_str}
+
+                logger.warning(f"无法从文本响应中解析代理信息: {text_response[:200]}")
+        else:
+            logger.warning(f"API请求失败，状态码: {api_response.status_code}")
+    except Exception as e:
+        logger.warning(f"获取代理异常: {e}")
+
+    return None
+
+def should_use_pinzan_proxy(url):
+    """
+    检查是否应该使用品赞代理访问给定URL
+
+    品赞代理全部是国内IP，只适合访问国内网站
+
+    Args:
+        url (str): 要访问的URL
+
+    Returns:
+        bool: 如果应该使用品赞代理返回True，否则返回False
+    """
+    # 如果URL为空，返回False
+    if not url:
+        return False
+
+    # 如果是国内网站，返回True
+    return is_china_website(url)
+
+def test_proxy(proxy, timeout=3, retries=2):
+    """
+    测试代理连接
+
+    测试代理连接是否可用
+
+    Args:
+        proxy (dict): 代理配置，格式为 {'http': 'http://...', 'https': 'http://...'}
+        timeout (int): 连接超时时间，单位为秒，默认为3秒
+        retries (int): 每个网站的重试次数，默认为2次
+
+    Returns:
+        bool: 测试是否成功
+    """
+    if not proxy:
+        return False
+
+    # 测试网站列表 - 只使用国内网站（因为品赞代理全部是国内IP）
+    test_urls = [
+        'http://www.baidu.com',  # 百度，国内最常用的网站
+        'http://www.qq.com',     # 腾讯，国内常用网站
+        'http://www.163.com',    # 网易，国内常用网站
+        'http://www.sina.com.cn' # 新浪，国内常用网站
+    ]
+
+    for url in test_urls:
+        # 对每个网站进行多次尝试
+        for retry in range(retries):
+            try:
+                logger.info(f"测试代理连接: {proxy}, URL: {url}, 尝试次数: {retry+1}/{retries}")
+                test_response = requests.get(
+                    url,
+                    proxies=proxy,
+                    timeout=timeout,
+                    verify=False  # 忽略SSL证书验证
+                )
+                if test_response.status_code == 200:
+                    logger.info(f"代理连接测试成功: {url}")
+                    return True
+                else:
+                    logger.warning(f"代理连接测试失败: {url}, 状态码: {test_response.status_code}, 尝试次数: {retry+1}/{retries}")
+            except Exception as e:
+                logger.warning(f"代理连接测试异常: {url}, 错误: {e}, 尝试次数: {retry+1}/{retries}")
+
+            # 如果不是最后一次尝试，等待一下再重试
+            if retry < retries - 1:
+                import time
+                time.sleep(0.5)  # 等待500毫秒再重试
+
+    # 如果所有测试都失败，尝试不使用账号密码
+    if 'http' in proxy and '@' in proxy['http']:
+        try:
+            # 提取IP和端口
+            auth_url = proxy['http']
+            ip_port = auth_url.split('@')[1]
+            proxy_str = f"http://{ip_port}"
+            logger.info(f"尝试不使用账号密码: {proxy_str}")
+            proxy_no_auth = {'http': proxy_str, 'https': proxy_str}
+
+            # 对无认证代理进行测试
+            for url in test_urls:
+                # 对每个网站进行多次尝试
+                for retry in range(retries):
+                    try:
+                        logger.info(f"测试代理连接(无认证): {proxy_no_auth}, URL: {url}, 尝试次数: {retry+1}/{retries}")
+                        test_response = requests.get(
+                            url,
+                            proxies=proxy_no_auth,
+                            timeout=timeout,
+                            verify=False
+                        )
+                        if test_response.status_code == 200:
+                            logger.info(f"代理连接测试成功(无认证): {url}")
+                            # 如果无认证模式成功，替换原始代理对象
+                            proxy['http'] = proxy_str
+                            proxy['https'] = proxy_str
+                            if 'ftp' in proxy:
+                                proxy['ftp'] = proxy_str
+                            return True
+                        else:
+                            logger.warning(f"代理连接测试失败(无认证): {url}, 状态码: {test_response.status_code}, 尝试次数: {retry+1}/{retries}")
+                    except Exception as e:
+                        logger.warning(f"代理连接测试异常(无认证): {url}, 错误: {e}, 尝试次数: {retry+1}/{retries}")
+
+                    # 如果不是最后一次尝试，等待一下再重试
+                    if retry < retries - 1:
+                        import time
+                        time.sleep(0.5)  # 等待500毫秒再重试
+        except Exception as e:
+            logger.warning(f"处理无认证代理异常: {e}")
+
+    return False
+
+def get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3):
+    """
+    获取并测试代理
+
+    从API获取代理，并测试连接是否可用
+
+    Args:
+        proxy_url (str): 代理API URL
+        max_retries (int): 每个代理的最大重试次数，默认为2次
+        num_proxies (int): 尝试获取的代理数量，默认为2个
+        timeout (int): 连接超时时间，单位为秒，默认为3秒
+
+    Returns:
+        dict: 代理配置，格式为 {'http': 'http://...', 'https': 'http://...'}
+        None: 如果获取失败或测试失败
+    """
+    if not proxy_url:
+        logger.warning("代理URL为空")
+        return None
+
+    # 标准化代理URL
+    proxy_url = normalize_proxy_url(proxy_url)
+    if not proxy_url:
+        logger.warning("标准化代理URL失败")
+        return None
+
+    # 尝试获取多个代理
+    for i in range(num_proxies):
+        try:
+            # 获取代理
+            proxy = get_proxy_from_api(proxy_url)
+            if not proxy:
+                logger.warning(f"第 {i+1}/{num_proxies} 次获取代理失败")
+                # 如果获取失败，等待一下再重试
+                if i < num_proxies - 1:
+                    time.sleep(1)  # 等待一秒再重试
+                continue
+
+            # 添加FTP代理支持
+            if 'http' in proxy and 'https' in proxy:
+                # 添加FTP代理支持，使用与其他协议相同的代理地址
+                proxy['ftp'] = proxy['http']
+
+            # 测试代理，使用改进的test_proxy函数
+            if test_proxy(proxy, timeout=timeout, retries=max_retries):
+                logger.info(f"第 {i+1}/{num_proxies} 个代理测试成功")
+                return proxy
+
+            logger.warning(f"第 {i+1}/{num_proxies} 个代理测试失败")
+            # 如果测试失败，等待一下再获取下一个代理
+            if i < num_proxies - 1:
+                time.sleep(1)  # 等待一秒再重试
+        except Exception as e:
+            logger.error(f"获取或测试代理异常: {e}")
+            # 如果发生异常，等待一下再重试
+            if i < num_proxies - 1:
+                time.sleep(1)  # 等待一秒再重试
+
+    logger.error(f"尝试了 {num_proxies} 个代理，均测试失败")
+    return None

--- a/docs/proxy/pinzan_proxy_config.md
+++ b/docs/proxy/pinzan_proxy_config.md
@@ -1,0 +1,241 @@
+# 品赞IP代理配置指南
+
+本文档提供了品赞IP代理的详细配置指南，包括API格式、认证方式和使用示例。
+
+> **重要提示：品赞IP代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站（如Google、OpenAI等）。系统已经自动判断网站类型，只对国内网站使用品赞代理。**
+
+## API格式
+
+品赞IP代理提供了两种API格式：
+
+### 1. TXT格式（白名单模式）
+
+TXT格式API不需要账号密码，但需要将您的IP添加到白名单：
+
+```
+http://service.ipzan.com/core-extract?num=1&no=YOUR_NO&minute=1&format=txt&repeat=1&protocol=1&pool=ordinary
+```
+
+### 2. JSON格式（认证模式）
+
+JSON格式API需要提供认证信息，但不受白名单限制：
+
+```
+http://service.ipzan.com/core-extract?num=1&no=YOUR_NO&minute=1&format=json&repeat=1&protocol=1&pool=ordinary&mode=auth&secret=YOUR_SECRET
+```
+
+## 参数说明
+
+API URL中的参数说明：
+
+- `num`: 提取数量，建议设置为1
+- `no`: 品赞账号编号
+- `minute`: 有效时长（分钟）
+- `format`: 返回格式，可选txt或json
+- `repeat`: 是否允许重复提取，1表示允许
+- `protocol`: 代理协议，1表示HTTP，2表示HTTPS，3表示SOCKS5
+- `pool`: 代理池类型，ordinary表示普通池
+- `mode`: 认证模式，auth表示使用认证
+- `secret`: 认证密钥
+
+## 配置方法
+
+### 1. 环境变量配置
+
+在`.env`文件中配置品赞API URL：
+
+```
+PINZAN_API_URL=http://service.ipzan.com/core-extract?num=1&no=YOUR_NO&minute=1&format=json&repeat=1&protocol=1&pool=ordinary&mode=auth&secret=YOUR_SECRET
+```
+
+### 2. 代码中直接配置
+
+在代码中直接配置品赞API URL：
+
+```python
+proxy_url = "http://service.ipzan.com/core-extract?num=1&no=YOUR_NO&minute=1&format=json&repeat=1&protocol=1&pool=ordinary&mode=auth&secret=YOUR_SECRET"
+```
+
+## 使用示例
+
+### 1. 获取代理
+
+```python
+import requests
+
+def get_proxy_from_pinzan(proxy_url):
+    try:
+        # 确保使用HTTP协议
+        if proxy_url.startswith('https://'):
+            proxy_url = proxy_url.replace('https://', 'http://')
+
+        response = requests.get(proxy_url, timeout=10)
+
+        if response.status_code == 200:
+            content_type = response.headers.get('Content-Type', '')
+
+            if 'json' in content_type:
+                # JSON格式响应
+                data = response.json()
+
+                if isinstance(data, list) and len(data) > 0:
+                    proxy_data = data[0]
+                    proxy_str = f"http://{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                    # 如果有用户名和密码，添加认证信息
+                    if proxy_data.get('user') and proxy_data.get('pass'):
+                        proxy_str = f"http://{proxy_data.get('user')}:{proxy_data.get('pass')}@{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                    return proxy_str
+            else:
+                # 文本格式响应
+                lines = response.text.strip().split('\n')
+                if lines and len(lines) > 0:
+                    proxy_line = lines[0].strip()
+
+                    # 检查是否已经是完整的代理URL
+                    if proxy_line.startswith('http://') or proxy_line.startswith('https://'):
+                        return proxy_line
+
+                    # 否则假设是IP:端口格式
+                    return f"http://{proxy_line}"
+
+        return None
+    except Exception as e:
+        print(f"从品赞API获取代理异常: {e}")
+        return None
+```
+
+### 2. 使用代理
+
+```python
+import requests
+
+def use_proxy(proxy_url):
+    try:
+        # 获取代理
+        proxy = get_proxy_from_pinzan(proxy_url)
+
+        if not proxy:
+            print("无法获取代理")
+            return False
+
+        # 使用代理
+        proxies = {
+            'http': proxy,
+            'https': proxy
+        }
+
+        # 测试代理
+        response = requests.get('http://httpbin.org/ip', proxies=proxies, timeout=10)
+
+        if response.status_code == 200:
+            print(f"使用代理成功，当前IP: {response.json().get('origin')}")
+            return True
+        else:
+            print(f"使用代理失败，状态码: {response.status_code}")
+            return False
+    except Exception as e:
+        print(f"使用代理异常: {e}")
+        return False
+```
+
+## 协议支持
+
+品赞IP代理支持多种协议：
+
+### 1. HTTP代理
+
+HTTP代理是最基本的代理类型，适用于大多数HTTP请求：
+
+```
+protocol=1
+```
+
+### 2. HTTPS代理
+
+HTTPS代理用于加密的HTTPS请求：
+
+```
+protocol=2
+```
+
+### 3. SOCKS5代理
+
+SOCKS5代理提供更高级的功能，支持TCP和UDP：
+
+```
+protocol=3
+```
+
+## 网站分类与代理适用性
+
+系统自动判断网站类型，只对国内网站使用品赞代理。
+
+### 1. 国内网站判断
+
+系统通过以下方式判断网站是否为国内网站：
+
+- 域名后缀：`.cn`、`.com.cn`、`.net.cn`、`.org.cn`、`.gov.cn`、`.edu.cn`等
+- 常见国内网站域名：`baidu.com`、`qq.com`、`163.com`、`wjx.cn`等
+- 本地地址：`localhost`、`127.0.0.1`等
+
+### 2. 代理适用性检查
+
+系统提供了`should_use_pinzan_proxy`函数，用于判断是否应该使用品赞代理访问给定URL：
+
+```python
+# 检查是否应该使用品赞代理
+if should_use_pinzan_proxy(url):
+    # 使用品赞代理
+    proxy = get_proxy_from_api(proxy_url)
+else:
+    # 使用直接连接或其他代理
+    proxy = None
+```
+
+### 3. LLM提供商分类
+
+系统会根据LLM提供商的地域特性决定是否使用品赞代理：
+
+- 国内LLM提供商（阿里云、百度、智谱）：使用品赞代理
+- 国外LLM提供商（如OpenAI）：不使用品赞代理，而是使用直接连接或其他代理
+
+## 常见问题
+
+### 1. 白名单问题
+
+**问题**: 使用TXT格式API但未将IP添加到白名单
+**解决方案**:
+- 登录品赞后台添加IP到白名单
+- 使用JSON格式API（认证模式）
+
+### 2. 认证问题
+
+**问题**: 使用JSON格式API但认证失败
+**解决方案**:
+- 检查no和secret是否正确
+- 确认账号是否有效
+
+### 3. 代理质量问题
+
+**问题**: 代理质量不稳定
+**解决方案**:
+- 使用高质量代理池
+- 实现代理质量检测
+- 添加代理轮换机制
+
+### 4. 国外网站访问问题
+
+**问题**: 使用品赞代理访问国外网站失败
+**解决方案**:
+- 不要使用品赞代理访问国外网站
+- 使用其他支持国外访问的代理服务
+- 系统已自动判断网站类型，只对国内网站使用品赞代理
+
+## 相关文档
+
+- [测试指南](../testing_guide.md)
+- [代理测试文档](../testing/proxy_testing.md)
+- [代理优化文档](proxy_optimization.md)
+- [使用示例文档](../examples/usage_examples.md)

--- a/docs/proxy/proxy_optimization.md
+++ b/docs/proxy/proxy_optimization.md
@@ -1,0 +1,375 @@
+# 代理优化文档
+
+本文档提供了代理基类和工厂类的优化说明，包括设计思路、实现细节和使用示例。
+
+> **重要提示：品赞IP代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站。系统已经自动判断网站类型，只对国内网站使用品赞代理。**
+
+## 设计思路
+
+代理优化的主要目标是：
+
+1. 提高代码复用性
+2. 增强可扩展性
+3. 简化使用方式
+4. 提升错误处理能力
+5. 智能判断代理适用性
+
+为此，我们采用了工厂模式和策略模式的组合，通过代理工厂类创建不同类型的代理实例。同时，我们添加了网站分类和代理适用性检查功能，确保只对适合的网站使用品赞代理。
+
+## 代理基类
+
+代理基类定义了所有代理类型的通用接口和行为：
+
+```python
+class BaseProxy:
+    """代理基类"""
+
+    def __init__(self, proxy_url=None):
+        """初始化代理"""
+        self.proxy_url = proxy_url
+        self.proxy_dict = None
+        self.last_used = None
+        self.success_count = 0
+        self.fail_count = 0
+
+    def get_proxy(self):
+        """获取代理"""
+        raise NotImplementedError("子类必须实现get_proxy方法")
+
+    def test_proxy(self):
+        """测试代理"""
+        raise NotImplementedError("子类必须实现test_proxy方法")
+
+    def format_proxy(self, proxy_str):
+        """格式化代理字符串为代理字典"""
+        if not proxy_str:
+            return None
+
+        self.proxy_dict = {
+            'http': proxy_str,
+            'https': proxy_str
+        }
+
+        return self.proxy_dict
+
+    def update_stats(self, success=True):
+        """更新代理使用统计"""
+        self.last_used = datetime.now()
+        if success:
+            self.success_count += 1
+        else:
+            self.fail_count += 1
+```
+
+## 代理工厂类
+
+代理工厂类负责创建不同类型的代理实例：
+
+```python
+def get_proxy_instance(proxy_type='pinzan', proxy_url=None):
+    """
+    获取代理实例
+
+    Args:
+        proxy_type: 代理类型，支持'pinzan'、'custom'等
+        proxy_url: 代理URL，如果为None则使用环境变量中的配置
+
+    Returns:
+        代理实例
+    """
+    if proxy_type == 'pinzan':
+        from .pinzan_proxy import PinzanProxy
+        return PinzanProxy(proxy_url)
+    elif proxy_type == 'custom':
+        from .custom_proxy import CustomProxy
+        return CustomProxy(proxy_url)
+    else:
+        raise ValueError(f"不支持的代理类型: {proxy_type}")
+```
+
+## 品赞代理实现
+
+品赞代理类继承自代理基类，实现了特定的获取和测试方法：
+
+```python
+class PinzanProxy(BaseProxy):
+    """品赞代理类"""
+
+    def __init__(self, proxy_url=None):
+        """初始化品赞代理"""
+        super().__init__(proxy_url)
+        if not self.proxy_url:
+            self.proxy_url = os.environ.get('PINZAN_API_URL')
+
+    def get_proxy(self):
+        """从品赞API获取代理"""
+        try:
+            # 确保使用HTTP协议
+            if self.proxy_url.startswith('https://'):
+                self.proxy_url = self.proxy_url.replace('https://', 'http://')
+
+            response = requests.get(self.proxy_url, timeout=10)
+
+            if response.status_code == 200:
+                content_type = response.headers.get('Content-Type', '')
+
+                if 'json' in content_type:
+                    # JSON格式响应
+                    data = response.json()
+
+                    if isinstance(data, list) and len(data) > 0:
+                        proxy_data = data[0]
+                        proxy_str = f"http://{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                        # 如果有用户名和密码，添加认证信息
+                        if proxy_data.get('user') and proxy_data.get('pass'):
+                            proxy_str = f"http://{proxy_data.get('user')}:{proxy_data.get('pass')}@{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                        return self.format_proxy(proxy_str)
+                else:
+                    # 文本格式响应
+                    lines = response.text.strip().split('\n')
+                    if lines and len(lines) > 0:
+                        proxy_line = lines[0].strip()
+
+                        # 检查是否已经是完整的代理URL
+                        if not (proxy_line.startswith('http://') or proxy_line.startswith('https://')):
+                            proxy_line = f"http://{proxy_line}"
+
+                        return self.format_proxy(proxy_line)
+
+            return None
+        except Exception as e:
+            logger.error(f"从品赞API获取代理异常: {e}")
+            return None
+
+    def test_proxy(self):
+        """测试代理连接"""
+        if not self.proxy_dict:
+            self.proxy_dict = self.get_proxy()
+
+        if not self.proxy_dict:
+            return False
+
+        try:
+            response = requests.get('http://httpbin.org/ip', proxies=self.proxy_dict, timeout=10)
+
+            if response.status_code == 200:
+                self.update_stats(success=True)
+                return True
+            else:
+                self.update_stats(success=False)
+                return False
+        except Exception as e:
+            logger.error(f"测试代理连接异常: {e}")
+            self.update_stats(success=False)
+            return False
+```
+
+## 使用示例
+
+### 1. 基本使用
+
+```python
+from backend.core.proxy.proxy_factory import get_proxy_instance
+
+# 创建品赞代理实例
+proxy = get_proxy_instance('pinzan')
+
+# 获取代理
+proxy_dict = proxy.get_proxy()
+
+# 测试代理
+if proxy.test_proxy():
+    print("代理可用")
+else:
+    print("代理不可用")
+```
+
+### 2. 与LLM结合使用
+
+```python
+from backend.core.proxy.proxy_factory import get_proxy_instance
+from backend.core.llm_generator import LLMGenerator
+
+# 创建品赞代理实例
+proxy = get_proxy_instance('pinzan')
+
+# 获取代理
+proxy_dict = proxy.get_proxy()
+
+if proxy_dict:
+    # 创建LLM生成器，使用代理
+    llm_gen = LLMGenerator(
+        provider='aliyun',
+        api_key=os.environ.get('ALIYUN_API_KEY'),
+        proxy=proxy_dict['http']  # 使用http代理
+    )
+
+    # 测试LLM生成
+    response = llm_gen.generate_text("Hello")
+    print(response)
+```
+
+## 网站分类与代理适用性
+
+为了解决品赞代理只能访问国内网站的限制，我们添加了网站分类和代理适用性检查功能。
+
+### 1. 国内网站判断
+
+```python
+def is_china_website(url):
+    """
+    检查URL是否为国内网站
+
+    通过域名后缀和常见国内网站域名判断
+
+    Args:
+        url (str): 要检查的URL
+
+    Returns:
+        bool: 如果是国内网站返回True，否则返回False
+    """
+    # 如果是本地地址或内网地址，返回True
+    if url.startswith('http://localhost') or url.startswith('http://127.0.0.1'):
+        return True
+
+    # 解析URL获取域名
+    parsed_url = urlparse(url)
+    domain = parsed_url.netloc.lower()
+
+    # 如果没有域名，返回False
+    if not domain:
+        return False
+
+    # 检查域名后缀
+    china_tlds = ['.cn', '.com.cn', '.net.cn', '.org.cn', '.gov.cn', '.edu.cn']
+    for tld in china_tlds:
+        if domain.endswith(tld):
+            return True
+
+    # 常见国内网站域名
+    china_domains = [
+        'baidu.com', 'qq.com', '163.com', 'sina.com.cn', 'sohu.com',
+        'taobao.com', 'jd.com', 'weibo.com', 'aliyun.com', 'tencent.com',
+        'bilibili.com', 'zhihu.com', 'douban.com', 'iqiyi.com', 'youku.com',
+        'csdn.net', 'cnblogs.com', '126.com', 'ctrip.com', 'meituan.com',
+        'wjx.cn', 'wjx.top'  # 问卷星域名
+    ]
+
+    for china_domain in china_domains:
+        if domain == china_domain or domain.endswith('.' + china_domain):
+            return True
+
+    return False
+```
+
+### 2. 代理适用性检查
+
+```python
+def should_use_pinzan_proxy(url):
+    """
+    检查是否应该使用品赞代理访问给定URL
+
+    品赞代理全部是国内IP，只适合访问国内网站
+
+    Args:
+        url (str): 要访问的URL
+
+    Returns:
+        bool: 如果应该使用品赞代理返回True，否则返回False
+    """
+    # 如果URL为空，返回False
+    if not url:
+        return False
+
+    # 如果是国内网站，返回True
+    return is_china_website(url)
+```
+
+### 3. LLM提供商分类
+
+对于LLM提供商，我们根据其地域特性决定是否使用品赞代理：
+
+```python
+# 检查是否为国内LLM提供商
+ is_china_llm = llm_type in ['aliyun', 'baidu', 'zhipu']
+ if not is_china_llm:
+     logger.warning(f"品赞代理不适合访问国外LLM提供商({llm_type})，将使用直接连接")
+     # 如果不是国内LLM，不使用品赞代理
+     proxy_url = None
+```
+
+## 优化建议
+
+### 1. 代理池实现
+
+为了提高代理的可用性和性能，可以实现代理池：
+
+```python
+class ProxyPool:
+    """代理池类"""
+
+    def __init__(self, proxy_type='pinzan', pool_size=5):
+        """初始化代理池"""
+        self.proxy_type = proxy_type
+        self.pool_size = pool_size
+        self.proxies = []
+        self.init_pool()
+
+    def init_pool(self):
+        """初始化代理池"""
+        for _ in range(self.pool_size):
+            proxy = get_proxy_instance(self.proxy_type)
+            if proxy.get_proxy() and proxy.test_proxy():
+                self.proxies.append(proxy)
+
+    def get_proxy(self):
+        """获取代理"""
+        if not self.proxies:
+            return None
+
+        # 使用轮询策略
+        proxy = self.proxies.pop(0)
+        self.proxies.append(proxy)
+
+        return proxy.proxy_dict
+```
+
+### 2. 错误重试机制
+
+添加错误重试机制，提高代理获取的成功率：
+
+```python
+def get_and_test_proxy(proxy_url, max_retries=3, num_proxies=3):
+    """
+    获取并测试代理，带重试机制
+
+    Args:
+        proxy_url: 代理API URL
+        max_retries: 最大重试次数
+        num_proxies: 尝试的代理数量
+
+    Returns:
+        可用的代理字典
+    """
+    for _ in range(max_retries):
+        for _ in range(num_proxies):
+            proxy = get_proxy_instance('pinzan', proxy_url)
+            proxy_dict = proxy.get_proxy()
+
+            if proxy_dict and proxy.test_proxy():
+                return proxy_dict
+
+        # 等待一段时间再重试
+        time.sleep(2)
+
+    return None
+```
+
+## 相关文档
+
+- [测试指南](../testing_guide.md)
+- [代理测试文档](../testing/proxy_testing.md)
+- [品赞代理配置文档](pinzan_proxy_config.md)
+- [使用示例文档](../examples/usage_examples.md)

--- a/docs/testing/llm_testing.md
+++ b/docs/testing/llm_testing.md
@@ -1,0 +1,211 @@
+# LLM测试指南
+
+本文档提供了LLM（大语言模型）测试的详细指南，包括不同提供商的配置、测试类型和常见问题解决方案。
+
+## LLM提供商配置
+
+系统支持多种LLM提供商，每种提供商都需要特定的配置：
+
+### 1. OpenAI
+
+- **环境变量**: `OPENAI_API_KEY`
+- **支持模型**: gpt-3.5-turbo, gpt-4等
+- **配置示例**:
+  ```python
+  config = {
+      'provider': 'openai',
+      'api_key': os.environ.get('OPENAI_API_KEY'),
+      'model': 'gpt-3.5-turbo'  # 可选，默认为gpt-3.5-turbo
+  }
+  ```
+
+### 2. 阿里云
+
+- **环境变量**: `ALIYUN_API_KEY`
+- **支持模型**: qwen-turbo, qwen-plus等
+- **配置示例**:
+  ```python
+  config = {
+      'provider': 'aliyun',
+      'api_key': os.environ.get('ALIYUN_API_KEY'),
+      'model': 'qwen-turbo'  # 可选，默认为qwen-turbo
+  }
+  ```
+
+### 3. 智谱AI
+
+- **环境变量**: `ZHIPU_API_KEY`
+- **支持模型**: chatglm_turbo, chatglm_pro等
+- **配置示例**:
+  ```python
+  config = {
+      'provider': 'zhipu',
+      'api_key': os.environ.get('ZHIPU_API_KEY'),
+      'model': 'chatglm_turbo'  # 可选，默认为chatglm_turbo
+  }
+  ```
+
+### 4. Google Gemini
+
+- **环境变量**: `GEMINI_API_KEY`
+- **支持模型**: gemini-pro等
+- **配置示例**:
+  ```python
+  config = {
+      'provider': 'gemini',
+      'api_key': os.environ.get('GEMINI_API_KEY'),
+      'model': 'gemini-pro'  # 可选，默认为gemini-pro
+  }
+  ```
+
+### 5. 兔子API
+
+- **环境变量**: `TUZI_API_KEY`
+- **配置示例**:
+  ```python
+  config = {
+      'provider': 'tuzi',
+      'api_key': os.environ.get('TUZI_API_KEY')
+  }
+  ```
+
+## 测试类型
+
+系统支持多种测试类型，可以根据需要选择：
+
+### 1. 基本连接测试
+
+测试与LLM提供商的API连接是否正常：
+
+```python
+from backend.core.llm_generator import LLMGenerator
+
+# 创建LLM生成器
+llm_gen = LLMGenerator(provider='aliyun', api_key='your_api_key')
+
+# 测试连接
+response = llm_gen.generate_text("Hello")
+print(response)
+```
+
+### 2. 问卷答案生成测试
+
+测试LLM是否能正确生成问卷答案：
+
+```python
+from backend.core.llm_generator import LLMGenerator
+
+# 创建LLM生成器
+llm_gen = LLMGenerator(provider='aliyun', api_key='your_api_key')
+
+# 准备问卷数据
+survey = {
+    'title': '测试问卷',
+    'questions': [
+        {
+            'index': 1,
+            'type': 3,  # 单选题
+            'title': '您的性别是？',
+            'options': ['男', '女']
+        },
+        {
+            'index': 2,
+            'type': 1,  # 填空题
+            'title': '请简述您的工作经历'
+        }
+    ]
+}
+
+# 生成答案
+answers = llm_gen.generate_answers(survey)
+print(answers)
+```
+
+### 3. 代理兼容性测试
+
+测试LLM是否能与代理正常配合使用：
+
+```python
+from backend.core.llm_generator import LLMGenerator
+
+# 创建带代理的LLM生成器
+llm_gen = LLMGenerator(
+    provider='aliyun',
+    api_key='your_api_key',
+    proxy='http://your_proxy_url'
+)
+
+# 测试生成
+response = llm_gen.generate_text("Hello")
+print(response)
+```
+
+## 参数化测试
+
+系统提供了参数化测试脚本，支持通过命令行参数配置测试选项：
+
+```bash
+python examples/parameterized_test.py --test-type [llm|proxy|combined] --provider [openai|zhipu|aliyun|gemini|tuzi] --use-proxy [true|false]
+```
+
+### 参数说明
+
+- `--test-type`: 测试类型
+  - `llm`: 仅测试LLM功能
+  - `proxy`: 仅测试代理功能
+  - `combined`: 测试LLM和代理的组合使用（默认）
+
+- `--provider`: LLM提供商
+  - `openai`: OpenAI
+  - `zhipu`: 智谱AI
+  - `aliyun`: 阿里云（默认）
+  - `gemini`: Google Gemini
+  - `tuzi`: 兔子API
+
+- `--model`: LLM模型名称（可选）
+  - 例如：`gpt-3.5-turbo`、`qwen-turbo`等
+
+- `--use-proxy`: 是否使用代理（仅对llm测试类型有效）
+  - `true`: 使用代理
+  - `false`: 不使用代理（默认）
+
+## 常见问题
+
+### 1. API密钥问题
+
+**问题**: API密钥无效或过期
+**解决方案**:
+- 检查环境变量是否正确设置
+- 确认API密钥是否有效
+- 检查API密钥是否有足够的配额
+
+### 2. 网络连接问题
+
+**问题**: 无法连接到LLM提供商的API
+**解决方案**:
+- 检查网络连接
+- 尝试使用代理
+- 确认API服务是否可用
+
+### 3. 响应格式问题
+
+**问题**: LLM返回的响应格式不正确
+**解决方案**:
+- 检查提示词是否正确
+- 调整模型参数
+- 尝试不同的模型
+
+### 4. 代理兼容性问题
+
+**问题**: LLM无法与代理正常配合使用
+**解决方案**:
+- 确认代理格式是否正确
+- 检查代理是否可用
+- 尝试不同的代理提供商
+
+## 相关文档
+
+- [测试指南](../testing_guide.md)
+- [代理测试文档](proxy_testing.md)
+- [品赞代理配置文档](../proxy/pinzan_proxy_config.md)
+- [使用示例文档](../examples/usage_examples.md)

--- a/docs/testing/proxy_testing.md
+++ b/docs/testing/proxy_testing.md
@@ -1,0 +1,340 @@
+# 代理测试指南
+
+本文档提供了代理功能测试的详细指南，包括不同类型代理的配置、测试方法和常见问题解决方案。
+
+> **重要提示：品赞IP代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站。系统已经自动判断网站类型，只对国内网站使用品赞代理。**
+
+## 代理类型
+
+系统支持多种类型的代理：
+
+### 1. HTTP代理
+
+HTTP代理是最基本的代理类型，适用于大多数HTTP请求：
+
+```python
+proxy = "http://username:password@host:port"
+```
+
+### 2. HTTPS代理
+
+HTTPS代理用于加密的HTTPS请求：
+
+```python
+proxy = "https://username:password@host:port"
+```
+
+### 3. SOCKS5代理
+
+SOCKS5代理提供更高级的功能，支持TCP和UDP：
+
+```python
+proxy = "socks5://username:password@host:port"
+```
+
+## 代理提供商
+
+### 品赞代理
+
+品赞代理是系统默认支持的代理提供商：
+
+- **环境变量**: `PINZAN_API_URL`
+- **API格式**:
+  - TXT格式: `http://service.ipzan.com/core-extract?num=1&no=xxxxx&minute=1&format=txt&repeat=1&protocol=1&pool=ordinary`
+  - JSON格式: `http://service.ipzan.com/core-extract?num=1&no=xxxxx&minute=1&format=json&repeat=1&protocol=1&pool=ordinary&mode=auth&secret=xxxxx`
+
+## 测试方法
+
+### 1. 基本连接测试
+
+测试代理连接是否正常：
+
+```python
+import requests
+
+def test_proxy(proxy_url):
+    try:
+        # 获取当前IP（不使用代理）
+        response = requests.get('http://httpbin.org/ip', timeout=10)
+        original_ip = response.json().get('origin')
+        print(f"当前IP: {original_ip}")
+
+        # 使用代理获取IP
+        proxies = {
+            'http': proxy_url,
+            'https': proxy_url
+        }
+        response = requests.get('http://httpbin.org/ip', proxies=proxies, timeout=10)
+        proxy_ip = response.json().get('origin')
+        print(f"代理IP: {proxy_ip}")
+
+        # 检查IP是否变化
+        if proxy_ip != original_ip:
+            print("代理测试成功!")
+            return True
+        else:
+            print("代理测试失败，IP未变化")
+            return False
+    except Exception as e:
+        print(f"代理测试异常: {e}")
+        return False
+```
+
+### 2. 品赞代理测试
+
+测试从品赞API获取代理并使用：
+
+```python
+import requests
+
+def get_proxy_from_pinzan(proxy_url):
+    try:
+        # 确保使用HTTP协议
+        if proxy_url.startswith('https://'):
+            proxy_url = proxy_url.replace('https://', 'http://')
+
+        response = requests.get(proxy_url, timeout=10)
+
+        if response.status_code == 200:
+            content_type = response.headers.get('Content-Type', '')
+
+            if 'json' in content_type:
+                # JSON格式响应
+                data = response.json()
+
+                if isinstance(data, list) and len(data) > 0:
+                    proxy_data = data[0]
+                    proxy_str = f"http://{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                    # 如果有用户名和密码，添加认证信息
+                    if proxy_data.get('user') and proxy_data.get('pass'):
+                        proxy_str = f"http://{proxy_data.get('user')}:{proxy_data.get('pass')}@{proxy_data.get('ip')}:{proxy_data.get('port')}"
+
+                    return proxy_str
+            else:
+                # 文本格式响应
+                lines = response.text.strip().split('\n')
+                if lines and len(lines) > 0:
+                    proxy_line = lines[0].strip()
+
+                    # 检查是否已经是完整的代理URL
+                    if proxy_line.startswith('http://') or proxy_line.startswith('https://'):
+                        return proxy_line
+
+                    # 否则假设是IP:端口格式
+                    return f"http://{proxy_line}"
+
+        return None
+    except Exception as e:
+        print(f"从品赞API获取代理异常: {e}")
+        return None
+```
+
+### 3. 网站分类测试
+
+测试系统对国内外网站的判断功能：
+
+```python
+def test_website_classification():
+    """测试网站分类功能"""
+    # 测试国内网站
+    china_websites = [
+        'http://www.baidu.com',
+        'http://www.qq.com',
+        'http://www.163.com',
+        'http://www.sina.com.cn',
+        'http://www.taobao.com',
+        'http://www.jd.com',
+        'http://www.gov.cn',
+        'http://www.edu.cn',
+        'http://www.wjx.cn'
+    ]
+
+    # 测试国外网站
+    foreign_websites = [
+        'http://www.google.com',
+        'http://www.facebook.com',
+        'http://www.twitter.com',
+        'http://www.youtube.com',
+        'http://www.amazon.com',
+        'http://www.openai.com',
+        'http://www.github.com',
+        'http://httpbin.org'
+    ]
+
+    # 测试本地网站
+    local_websites = [
+        'http://localhost:8080',
+        'http://127.0.0.1:5000',
+        'http://localhost'
+    ]
+
+    print("测试国内网站判断:")
+    for url in china_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        print(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+
+    print("测试国外网站判断:")
+    for url in foreign_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        print(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+
+    print("测试本地网站判断:")
+    for url in local_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        print(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+```
+
+### 4. 代理适用性测试
+
+测试系统对不同类型网站的代理选择功能：
+
+```python
+def test_proxy_selection():
+    """测试代理选择功能"""
+    # 测试国内网站
+    china_url = 'http://www.baidu.com'
+    # 测试国外网站
+    foreign_url = 'http://www.google.com'
+
+    # 品赞代理URL
+    pinzan_proxy_url = os.environ.get('PINZAN_API_URL')
+
+    # 测试国内网站使用品赞代理
+    if should_use_pinzan_proxy(china_url):
+        proxy = get_proxy_from_api(pinzan_proxy_url)
+        if proxy:
+            print(f"成功为国内网站 {china_url} 获取品赞代理: {proxy}")
+            # 测试代理连接
+            if test_proxy(proxy, timeout=5):
+                print(f"使用品赞代理访问国内网站 {china_url} 成功")
+            else:
+                print(f"使用品赞代理访问国内网站 {china_url} 失败")
+        else:
+            print(f"无法为国内网站 {china_url} 获取品赞代理")
+    else:
+        print(f"国内网站 {china_url} 判断失败，应该返回True")
+
+    # 测试国外网站不使用品赞代理
+    if not should_use_pinzan_proxy(foreign_url):
+        print(f"正确判断国外网站 {foreign_url} 不应使用品赞代理")
+        # 使用直接连接
+        try:
+            response = requests.get(foreign_url, timeout=10)
+            print(f"直接连接访问国外网站 {foreign_url} 成功，状态码: {response.status_code}")
+        except Exception as e:
+            print(f"直接连接访问国外网站 {foreign_url} 失败: {e}")
+    else:
+        print(f"国外网站 {foreign_url} 判断失败，应该返回False")
+```
+
+### 5. 参数化测试
+
+系统提供了参数化测试脚本，支持通过命令行参数配置测试选项：
+
+```bash
+python examples/parameterized_test.py --test-type proxy
+```
+
+## HTTP代理问题
+
+HTTP代理是最常用的代理类型，但也有一些常见问题：
+
+### 1. 认证问题
+
+**问题**: 代理需要认证但未提供认证信息
+**解决方案**:
+- 确保代理URL包含用户名和密码
+- 检查认证信息是否正确
+
+### 2. 连接超时
+
+**问题**: 连接代理服务器超时
+**解决方案**:
+- 检查代理服务器是否可用
+- 增加超时时间
+- 尝试其他代理服务器
+
+## HTTPS代理问题
+
+HTTPS代理用于加密连接，可能会有一些特殊问题：
+
+### 1. SSL证书问题
+
+**问题**: SSL证书验证失败
+**解决方案**:
+- 使用`verify=False`参数（不推荐用于生产环境）
+- 配置正确的证书
+- 使用HTTP代理替代
+
+### 2. 协议转换问题
+
+**问题**: 代理服务器不支持HTTPS
+**解决方案**:
+- 将HTTPS代理URL改为HTTP
+- 使用支持HTTPS的代理服务器
+
+## SOCKS5代理问题
+
+SOCKS5代理提供更高级的功能，但也有一些特殊问题：
+
+### 1. 依赖问题
+
+**问题**: 缺少SOCKS5支持
+**解决方案**:
+- 安装`requests[socks]`或`PySocks`
+- 确保正确导入SOCKS5支持模块
+
+### 2. 协议兼容性
+
+**问题**: 某些请求与SOCKS5不兼容
+**解决方案**:
+- 尝试使用HTTP/HTTPS代理
+- 检查SOCKS5代理配置
+
+## 常见问题
+
+### 1. 代理可用性问题
+
+**问题**: 代理服务器不可用或已过期
+**解决方案**:
+- 定期刷新代理
+- 实现代理轮换机制
+- 添加代理可用性检查
+
+### 2. IP限制问题
+
+**问题**: 目标网站限制代理IP访问
+**解决方案**:
+- 使用高质量代理
+- 降低请求频率
+- 实现IP轮换策略
+
+### 3. 性能问题
+
+**问题**: 使用代理导致请求变慢
+**解决方案**:
+- 选择低延迟代理
+- 实现代理性能监控
+- 对性能要求不高的请求才使用代理
+
+### 4. 品赞代理限制问题
+
+**问题**: 品赞代理只能访问国内网站
+**解决方案**:
+- 使用`is_china_website`函数判断网站类型
+- 使用`should_use_pinzan_proxy`函数决定是否使用品赞代理
+- 对国外网站使用直接连接或其他代理
+- 对国内LLM提供商（阿里云、百度、智谱）使用品赞代理
+- 对国外LLM提供商（如OpenAI）使用直接连接或其他代理
+
+## 相关文档
+
+- [测试指南](../testing_guide.md)
+- [LLM测试文档](llm_testing.md)
+- [品赞代理配置文档](../proxy/pinzan_proxy_config.md)
+- [代理优化文档](../proxy/proxy_optimization.md)
+- [使用示例文档](../examples/usage_examples.md)

--- a/test_proxy.py
+++ b/test_proxy.py
@@ -1,0 +1,232 @@
+"""
+----------------------------------------------------------------
+File name:                  test_proxy.py
+Author:                     Ignorant-lu
+Date created:               2025/05/01
+Description:                测试代理功能
+----------------------------------------------------------------
+
+Changed history:
+                            2025/05/01: 初始创建
+----------------------------------------------------------------
+"""
+
+import os
+import sys
+import logging
+import requests
+from dotenv import load_dotenv
+
+# 添加项目根目录到系统路径
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# 配置日志
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# 加载环境变量
+load_dotenv('.env.real')
+
+# 导入代理工具
+from backend.utils.proxy.utils import normalize_proxy_url, get_proxy_from_api, test_proxy, get_and_test_proxy, is_china_website, should_use_pinzan_proxy
+
+def test_get_proxy():
+    """测试获取代理"""
+    # 从环境变量获取代理URL
+    proxy_url = os.environ.get('PINZAN_API_URL')
+    if not proxy_url:
+        logger.error("环境变量中未设置PINZAN_API_URL")
+        return False
+
+    logger.info(f"原始代理URL: {proxy_url}")
+
+    # 标准化代理URL
+    normalized_url = normalize_proxy_url(proxy_url)
+    logger.info(f"标准化后的代理URL: {normalized_url}")
+
+    # 获取代理
+    proxy = get_proxy_from_api(normalized_url)
+    logger.info(f"获取到的代理: {proxy}")
+
+    if not proxy:
+        logger.error("获取代理失败")
+        return False
+
+    # 添加FTP代理支持
+    if 'http' in proxy and 'https' in proxy:
+        proxy['ftp'] = proxy['http']
+        logger.info(f"添加FTP代理支持: {proxy['ftp']}")
+
+    # 测试代理
+    logger.info("测试代理连接...")
+    if test_proxy(proxy, timeout=3, retries=2):
+        logger.info("代理连接测试成功")
+        return True
+    else:
+        logger.error("代理连接测试失败")
+        return False
+
+def test_get_and_test_proxy():
+    """测试获取并测试代理"""
+    # 从环境变量获取代理URL
+    proxy_url = os.environ.get('PINZAN_API_URL')
+    if not proxy_url:
+        logger.error("环境变量中未设置PINZAN_API_URL")
+        return False
+
+    logger.info(f"原始代理URL: {proxy_url}")
+
+    # 获取并测试代理，使用优化的参数
+    proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+    logger.info(f"获取并测试的代理: {proxy}")
+
+    if proxy:
+        # 打印详细信息
+        if 'http' in proxy:
+            logger.info(f"HTTP代理: {proxy['http']}")
+        if 'https' in proxy:
+            logger.info(f"HTTPS代理: {proxy['https']}")
+        if 'ftp' in proxy:
+            logger.info(f"FTP代理: {proxy['ftp']}")
+        logger.info("获取并测试代理成功")
+        return True
+    else:
+        logger.error("获取并测试代理失败")
+        return False
+
+def test_direct_request():
+    """测试直接请求"""
+    # 使用国内网站进行测试
+    test_url = 'http://www.baidu.com'
+    try:
+        logger.info(f"测试直接请求URL: {test_url}")
+        response = requests.get(test_url, timeout=3)
+        if response.status_code == 200:
+            logger.info(f"直接请求成功: {test_url}")
+            logger.info(f"响应内容长度: {len(response.text)} 字节")
+            return True
+        else:
+            logger.warning(f"直接请求失败: {test_url}, 状态码: {response.status_code}")
+            return False
+    except Exception as e:
+        logger.error(f"直接请求异常: {test_url}, 错误: {e}")
+        return False
+
+def test_proxy_request():
+    """测试代理请求"""
+    # 从环境变量获取代理URL
+    proxy_url = os.environ.get('PINZAN_API_URL')
+    if not proxy_url:
+        logger.error("环境变量中未设置PINZAN_API_URL")
+        return False
+
+    # 获取并测试代理
+    proxy = get_and_test_proxy(proxy_url, max_retries=2, num_proxies=2, timeout=3)
+    if not proxy:
+        logger.error("获取代理失败")
+        return False
+
+    # 测试多个国内网站（因为品赞代理全部是国内IP）
+    test_urls = [
+        'http://www.baidu.com',    # 百度
+        'http://www.qq.com',       # 腾讯
+        'http://www.163.com',      # 网易
+        'http://www.sina.com.cn',  # 新浪
+        'http://www.sohu.com'      # 搜狐
+    ]
+
+    success = False
+    for url in test_urls:
+        try:
+            logger.info(f"测试代理请求URL: {url}")
+            response = requests.get(url, proxies=proxy, timeout=3)
+            if response.status_code == 200:
+                logger.info(f"代理请求成功: {url}")
+                logger.info(f"响应内容: {response.text[:200]}...")
+                success = True
+                break
+            else:
+                logger.warning(f"代理请求失败: {url}, 状态码: {response.status_code}")
+        except Exception as e:
+            logger.warning(f"代理请求异常: {url}, 错误: {e}")
+
+    return success
+
+def test_website_classification():
+    """测试网站分类功能"""
+    # 测试国内网站
+    china_websites = [
+        'http://www.baidu.com',
+        'http://www.qq.com',
+        'http://www.163.com',
+        'http://www.sina.com.cn',
+        'http://www.taobao.com',
+        'http://www.jd.com',
+        'http://www.gov.cn',
+        'http://www.edu.cn'
+    ]
+
+    # 测试国外网站
+    foreign_websites = [
+        'http://www.google.com',
+        'http://www.facebook.com',
+        'http://www.twitter.com',
+        'http://www.youtube.com',
+        'http://www.amazon.com',
+        'http://www.openai.com',
+        'http://www.github.com',
+        'http://httpbin.org'
+    ]
+
+    # 测试本地网站
+    local_websites = [
+        'http://localhost:8080',
+        'http://127.0.0.1:5000',
+        'http://localhost'
+    ]
+
+    logger.info("测试国内网站判断:")
+    for url in china_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        logger.info(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+
+    logger.info("测试国外网站判断:")
+    for url in foreign_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        logger.info(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+
+    logger.info("测试本地网站判断:")
+    for url in local_websites:
+        result = is_china_website(url)
+        should_use = should_use_pinzan_proxy(url)
+        logger.info(f"{url} -> 国内网站: {result}, 应使用品赞代理: {should_use}")
+
+if __name__ == "__main__":
+    logger.info("开始测试代理功能")
+
+    # 测试网站分类
+    logger.info("测试网站分类...")
+    test_website_classification()
+
+    # 测试直接请求
+    logger.info("测试直接请求...")
+    test_direct_request()
+
+    # 测试获取代理
+    logger.info("测试获取代理...")
+    test_get_proxy()
+
+    # 测试获取并测试代理
+    logger.info("测试获取并测试代理...")
+    test_get_and_test_proxy()
+
+    # 测试代理请求
+    logger.info("测试代理请求...")
+    test_proxy_request()
+
+    logger.info("代理功能测试完成")


### PR DESCRIPTION
## 主要功能
- 修复导入错误，确保系统能够正常启动
- 添加网站分类功能，判断URL是否为国内网站
- 添加代理适用性检查，只对国内网站使用品赞代理
- 优化品赞API的解析逻辑，正确处理API响应

## 代理测试优化
- 添加详细的警告日志，提醒用户品赞代理的限制
- 优化代理测试逻辑，使用国内网站进行测试
- 添加测试脚本，验证网站分类和代理适用性功能

## LLM提供商分类
- 对国内LLM提供商（阿里云、百度、智谱）使用品赞代理
- 对国外LLM提供商（如OpenAI）使用直接连接或其他代理

## 文档更新
- 更新代理相关文档，添加品赞代理限制说明
- 添加网站分类和代理适用性测试文档

## 注意事项
品赞代理全部是国内IP，只能用于访问国内网站，不适合访问国外网站。
系统现在会自动判断网站类型，只对国内网站使用品赞代理，对国外网站使用直接连接或其他代理。